### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate_readme.yml
+++ b/.github/workflows/validate_readme.yml
@@ -1,4 +1,6 @@
 name: Validate README
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/6](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/6)

To fix the problem, an explicit `permissions` block should be added, granting only the permissions needed for the workflow. In this case, since the workflow only checks out the code and runs validation on it, the job only needs the ability to read repository contents. Therefore, a minimal permissions block of `contents: read` should be added. This can be placed at the workflow root (after the `name` declaration and before the `on` block), so it applies to all jobs in this workflow. No changes to any steps are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
