### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate_manifest.yml
+++ b/.github/workflows/validate_manifest.yml
@@ -1,4 +1,6 @@
 name: Validate Manifest
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/8](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/8)

To fix the problem, add an explicit permissions block to the workflow to restrict the GITHUB_TOKEN permissions. Since the workflow only needs to read repository contents (for checkout and validation), set `contents: read` at the workflow level (top-level), so all jobs inherit this minimal privilege. Edit `.github/workflows/validate_manifest.yml` and insert:

```yaml
permissions:
  contents: read
```

directly after the `name:` line and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
