### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update_dashboard.yml
+++ b/.github/workflows/update_dashboard.yml
@@ -1,4 +1,6 @@
 name: Update Glyphic Dashboard
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/9](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/9)

To fix the problem, add an explicit `permissions` key to the workflow file, restricting the GITHUB_TOKEN scope to what is strictly required. The workflow only checks out the repository and runs a Python script; there is no evidence of writing to issues, PRs, or repository content, so read-only access to contents is sufficient. The recommended change is to add the following block near the top of the file (ideally before `jobs:`):

```yaml
permissions:
  contents: read
```

No changes to steps or jobs are needed. No new methods, imports, or definitions are necessary; it is a YAML configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
