### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate_profiles.yml
+++ b/.github/workflows/generate_profiles.yml
@@ -1,5 +1,7 @@
 name: Generate Contributor Profiles
 
+permissions:
+  contents: read
 on:
   workflow_run:
     workflows: ["Update Contributor Honor Roll"]


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/10](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/10)

To fix the issue, you should add a `permissions:` block explicitly to the workflow. This can be achieved by placing the block at the root of the workflow YAML, applying to all jobs, or within the specific job that requires those permissions. Since the workflow does not appear to need write access (it only checks out code and runs a read-only Python script), the best fix is to set the minimal necessary permission: `contents: read`. The change should be made at the top level of `.github/workflows/generate_profiles.yml`, before the `jobs:` key, to ensure all jobs inherit these least privilege settings. No additional methods, imports, or library definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
