### PR TITLE
Potential fix for code scanning alert no. 53: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/metadata-validator.yml
+++ b/.github/workflows/metadata-validator.yml
@@ -10,6 +10,9 @@ on:
       - "docs/**"
       - "scripts/**"
 
+permissions:
+  contents: read
+
 jobs:
   validate-metadata:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/53](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/53)

Add an explicit `permissions` block to the workflow with least privilege.  
Best fix here: define workflow-level permissions right after `on:` triggers (or before `jobs:`) as:

- `contents: read`

This preserves existing behavior (checkout + script execution) while ensuring the token is restricted. No imports, methods, or dependencies are required since this is YAML config only.

File to edit:
- `.github/workflows/metadata-validator.yml`
- Insert `permissions:` block between the trigger section and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
