### PR TITLE
Potential fix for code scanning alert no. 54: Uncontrolled data used in path expression

### DIFF
--- a/docs/rtt/codes/generators/js/generate_rttcode.js
+++ b/docs/rtt/codes/generators/js/generate_rttcode.js
@@ -38,19 +38,19 @@ function ensureInsideRoot(root, candidate) {
     throw new Error("Path must refer to a file, not a directory");
   }
 
-  const resolvedPath = path.resolve(root, candidate);
-  const realPath = fs.realpathSync(resolvedPath);
-  const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
+  const normalizedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(normalizedRoot, candidate);
+  const rootWithSep = normalizedRoot.endsWith(path.sep) ? normalizedRoot : normalizedRoot + path.sep;
 
-  if (realPath !== root && !realPath.startsWith(rootWithSep)) {
+  if (resolvedPath !== normalizedRoot && !resolvedPath.startsWith(rootWithSep)) {
     throw new Error(`Path escape detected: ${candidate}`);
   }
 
-  if (!allowedExt.includes(path.extname(realPath))) {
+  if (!allowedExt.includes(path.extname(resolvedPath))) {
     throw new Error(`Invalid extension: must be one of ${allowedExt.join(", ")}`);
   }
 
-  return realPath;
+  return resolvedPath;
 }
 
 // --- Main generator ------------------------------------------------------


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/54](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/54)

General fix: canonicalize user input into a path under a fixed trusted root using `path.resolve`, verify containment, and only then use the sanitized path at file-write sink. For write targets, avoid `realpathSync` as the primary canonicalizer because destination files may not yet exist.

Best fix in this file:
- Update `ensureInsideRoot` to:
  - resolve both `root` and candidate with `path.resolve`,
  - verify resolved candidate is strictly inside root (or equal root if desired),
  - enforce extension allowlist on the resolved candidate,
  - return the resolved safe path.
- Keep existing argument checks and sink usage unchanged.
- This change is localized to `docs/rtt/codes/generators/js/generate_rttcode.js` in `ensureInsideRoot` (lines around 41–53 in snippet).

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
