### PR TITLE
Potential fix for code scanning alert no. 64: Code injection

### DIFF
--- a/node_modules/railroad-diagrams/railroad_diagrams.py
+++ b/node_modules/railroad-diagrams/railroad_diagrams.py
@@ -424,4 +424,5 @@ if __name__ == '__main__':
 
     import sys
     sys.stdout.write("<!doctype html><title>Test</title><style>svg.railroad-diagram{background-color:hsl(30,20%,95%);}svg.railroad-diagram path{stroke-width:3;stroke:black;fill:rgba(0,0,0,0);}svg.railroad-diagram text{font:bold 14px monospace;text-anchor:middle;}svg.railroad-diagram text.label{text-anchor:start;}svg.railroad-diagram text.comment{font:italic 12px monospace;}svg.railroad-diagram rect{stroke-width:3;stroke:black;fill:hsl(120,100%,90%);}</style>")
-    exec(open('css-example.py-js').read())
+    with open('css-example.py-js') as f:
+        sys.stdout.write(f.read())


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/64](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/64)

Best fix: remove dynamic code execution and replace it with a safe, non-evaluating operation.  
In this file, line 427 should no longer call `exec(...)`. If the intent is to include the example file contents in output, read and write it as plain text instead of executing it.

Change region: `node_modules/railroad-diagrams/railroad_diagrams.py`, in the `if __name__ == '__main__':` block near line 427.

No new dependencies are needed. No import changes required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
