### PR TITLE
Potential fix for code scanning alert no. 61: Full server-side request forgery

### DIFF
--- a/docs/validators/readme_validator.py
+++ b/docs/validators/readme_validator.py
@@ -1,6 +1,9 @@
 import os
 import re
+import socket
+import ipaddress
 import requests
+from urllib.parse import urlparse
 from bs4 import BeautifulSoup
 
 README_PATH = "README.md"
@@ -15,8 +18,47 @@ def extract_links(content):
     img_links = re.findall(r'src="(.*?)"', content)
     return md_links + html_links + img_links
 
+def _is_public_http_url(url):
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+        if not parsed.hostname:
+            return False
+
+        host = parsed.hostname
+        try:
+            host_ip = ipaddress.ip_address(host)
+            return not (
+                host_ip.is_private
+                or host_ip.is_loopback
+                or host_ip.is_link_local
+                or host_ip.is_reserved
+                or host_ip.is_multicast
+            )
+        except ValueError:
+            pass
+
+        addrinfos = socket.getaddrinfo(host, None)
+        for info in addrinfos:
+            ip_text = info[4][0]
+            resolved_ip = ipaddress.ip_address(ip_text)
+            if (
+                resolved_ip.is_private
+                or resolved_ip.is_loopback
+                or resolved_ip.is_link_local
+                or resolved_ip.is_reserved
+                or resolved_ip.is_multicast
+            ):
+                return False
+        return True
+    except:
+        return False
+
 def check_link(url):
     if url.startswith("http"):
+        if not _is_public_http_url(url):
+            return False
         try:
             r = requests.head(url, allow_redirects=True, timeout=5)
             return r.status_code == 200


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/61](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/61)

Use a strict URL validation gate before `requests.head` so only safe, expected external links are requested.

Best fix here (without changing intended functionality of checking HTTP links) is:
- Parse the URL with `urllib.parse.urlparse`.
- Allow only `http`/`https`.
- Require a non-empty hostname.
- Resolve hostname and block private/loopback/link-local/reserved/multicast IP targets (including DNS-resolved hosts) using `ipaddress` + `socket`.
- Reject malformed URLs and any resolution failure.
- Only then perform `requests.head`.

This change should be made in `docs/validators/readme_validator.py`:
1. Add imports for `socket`, `ipaddress`, and `urlparse`.
2. Add a helper function (for example `_is_public_http_url`) above `check_link`.
3. Update `check_link` line region to call this helper before issuing the request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
