### PR TITLE
Potential fix for code scanning alert no. 96: Full server-side request forgery

### DIFF
--- a/docs/sources/Good_Vibrations.py
+++ b/docs/sources/Good_Vibrations.py
@@ -50,9 +50,20 @@ def _is_allowed_html_source_url(url):
 
     if parsed.scheme != "https":
         return False
+    if parsed.params or parsed.query or parsed.fragment:
+        return False
+    if parsed.username or parsed.password or parsed.port is not None:
+        return False
 
     host = (parsed.hostname or "").lower()
-    return host == "wikipedia.org" or host.endswith(".wikipedia.org")
+    path = parsed.path.rstrip("/")
+
+    # Strict allowlist of known-good HTML source URLs.
+    allowed = {
+        ("en.wikipedia.org", "/wiki/List_of_particles"),
+        ("wikipedia.org", "/wiki/List_of_particles"),
+    }
+    return (host, path) in allowed
 
 # Extractor: Wikipedia Particle Resonance (HTML)
 def parse_wikipedia_html(url):


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/96](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/96)

Best fix: remove attacker control over destination by resolving input URLs against a server-side allowlist of exact approved URLs (or normalized forms), then only requesting the approved value.

In `docs/sources/Good_Vibrations.py`, tighten `_is_allowed_html_source_url` so it only allows specific known Wikipedia page URLs needed by this script (instead of any wikipedia host). Then in `parse_wikipedia_html`, use the normalized approved URL for `requests.get`. This preserves existing behavior for intended sources while preventing full-URL SSRF from modified JSON input.

Changes needed:
- Add URL normalization helper logic inside `_is_allowed_html_source_url` (using existing `urlparse` import).
- Enforce exact path allowlist and reject query/fragment/userinfo/port.
- Keep `https` requirement.
- Continue raising `ValueError` in `parse_wikipedia_html` when disallowed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
