### PR TITLE
Potential fix for code scanning alert no. 96: Full server-side request forgery

### DIFF
--- a/docs/sources/Good_Vibrations.py
+++ b/docs/sources/Good_Vibrations.py
@@ -4,6 +4,8 @@ import pdfplumber
 from datetime import datetime
 from urllib.parse import urlparse
 
+ALLOWED_WIKIPEDIA_PARTICLES_URL = "https://en.wikipedia.org/wiki/List_of_particles"
+
 # Load source definitions
 def load_sources():
     with open("Good_Vibrations_sources.json") as f:
@@ -98,7 +100,7 @@ def refresh_resonance_csv():
         elif src["parser"] == "pdf_table" and "bruker" in src["url"]:
             df = parse_bruker_pdf("bruker_nmr.pdf")
         elif src["parser"] == "html_table":
-            df = parse_wikipedia_html(src["url"])
+            df = parse_wikipedia_html(ALLOWED_WIKIPEDIA_PARTICLES_URL)
         else:
             continue
         all_data.append(df)


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/96](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/96)

General fix: do not pass externally supplied full URLs to HTTP clients. Instead, map trusted identifiers to server-side constant URLs and only request those constants.

Best fix here (without changing functionality): in `refresh_resonance_csv()`, ignore `src["url"]` for `html_table` sources and call `parse_wikipedia_html(...)` with a hardcoded allowed URL constant. This preserves current behavior (Wikipedia particle table fetch) while removing untrusted control of destination URL and satisfying CodeQL’s full-SSRF concern.

Change in `docs/sources/Good_Vibrations.py`:
- Add a module-level constant for the allowed Wikipedia URL.
- Update the `elif src["parser"] == "html_table":` branch to pass that constant instead of `src["url"]`.

No new methods are required; existing `_is_allowed_html_source_url` remains as defense in depth.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
