### PR TITLE
Potential fix for code scanning alert no. 98: Partial server-side request forgery

### DIFF
--- a/docs/validators/readme_validator.py
+++ b/docs/validators/readme_validator.py
@@ -86,10 +86,27 @@ def _canonicalize_allowed_http_url(url):
         if not _is_public_http_url(url):
             return None
 
+        path = parsed.path or "/"
+        if not path.startswith("/"):
+            return None
+        lowered_path = path.lower()
+        if (
+            "/../" in lowered_path
+            or lowered_path.endswith("/..")
+            or "/./" in lowered_path
+            or lowered_path.endswith("/.")
+            or "%2e" in lowered_path
+        ):
+            return None
+        if not re.fullmatch(r"/[A-Za-z0-9._~!$&'()*+,;=:@%/-]*", path):
+            return None
+
+        if parsed.query and not re.fullmatch(r"[A-Za-z0-9._~!$&'()*+,;=:@%/?-]*", parsed.query):
+            return None
+
         netloc = parsed.hostname.lower()
         if parsed.port:
             netloc = f"{netloc}:{parsed.port}"
-        path = parsed.path or "/"
         return f"{parsed.scheme}://{netloc}{path}" + (f"?{parsed.query}" if parsed.query else "")
     except:
         return None


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/98](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/98)

To fix this without changing intended functionality, add strict validation for URL path/query characters and path traversal patterns inside `_canonicalize_allowed_http_url`, and only build canonical URLs from validated components.

Best single approach in this file:
- In `docs/validators/readme_validator.py`, inside `_canonicalize_allowed_http_url` (around lines 75–95), validate:
  - path must start with `/`
  - path must not contain traversal indicators (`/../`, `/./`, trailing `/.` or `/..`, or encoded `%2e`)
  - path/query limited to a conservative safe character set
- Keep existing host/scheme/public-IP/redirect checks.
- Return `None` for invalid path/query so `check_link` refuses those URLs before `requests.head`.

No new dependencies are required; use existing `re` and `urllib.parse`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
