### PR TITLE
Potential fix for code scanning alert no. 98: Partial server-side request forgery

### DIFF
--- a/docs/validators/readme_validator.py
+++ b/docs/validators/readme_validator.py
@@ -112,7 +112,16 @@ def _canonicalize_allowed_http_url(url):
         return None
 
 def check_link(url):
-    if url.startswith("http"):
+    if not isinstance(url, str):
+        return False
+    url = url.strip()
+    if not url:
+        return False
+    if re.search(r"[\x00-\x20\x7f]", url):
+        return False
+
+    parsed = urlparse(url)
+    if parsed.scheme.lower() in ("http", "https"):
         current_url = _canonicalize_allowed_http_url(url)
         if not current_url:
             return False


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/98](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/98)

General fix: ensure outbound requests are made only to URLs that are both validated and explicitly constrained to a deterministic, normalized form, and reject ambiguous/unsafe URL forms earlier at extraction time so tainted strings never reach the request sink unless they pass strict policy.

Best single fix here: tighten `check_link` so it only processes absolute `http://` or `https://` links (case-insensitive) and rejects whitespace/control-character-containing URLs before canonicalization. This removes ambiguous prefix handling (`startswith("http")`) and prevents malformed inputs from reaching `requests.head`, while preserving existing behavior for valid links.

Changes needed in `docs/validators/readme_validator.py`:
- In `check_link`, replace `url.startswith("http")` with strict parsed-scheme validation.
- Add early rejection for non-string/empty URLs and URLs containing whitespace/control characters.
- Keep canonicalization and redirect validation flow unchanged.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
