### PR TITLE
Potential fix for code scanning alert no. 104: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/tools/cli/validate.py
+++ b/docs/resonance-substrate-model/tools/cli/validate.py
@@ -46,9 +46,7 @@ def ensure_within_root(path: Path, root: Path, label: str) -> Path:
 
     resolved_root = root.resolve()
     resolved = (resolved_root / candidate).resolve(strict=False)
-    try:
-        resolved.relative_to(resolved_root)
-    except ValueError:
+    if not resolved.is_relative_to(resolved_root):
         error(f"{label} escapes repository root: {candidate}")
     return resolved
 
@@ -212,6 +210,8 @@ def main():
             error("Missing --schema argument for data validation")
 
         schema_index = sys.argv.index("--schema") + 1
+        if schema_index >= len(sys.argv):
+            error("Missing schema path after --schema")
         schema_path = ensure_within_root(Path(sys.argv[schema_index]), repo_root, "Schema path")
         validate_data(target, schema_path)
 


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/104](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/104)

Best fix: harden `ensure_within_root` so untrusted input is canonicalized and validated using `Path.resolve()` on the combined path, reject non-JSON targets early (if applicable elsewhere already), and ensure CLI argument presence checks prevent out-of-range access. The key is to keep all user input constrained to `repo_root` using canonical path containment checks after join+resolve.

In `docs/resonance-substrate-model/tools/cli/validate.py`, update `ensure_within_root` to:

- Build `candidate` from the raw string.
- Reject absolute paths and traversal components.
- Compute `resolved = (root.resolve() / candidate).resolve(strict=False)`.
- Verify containment using `resolved.is_relative_to(resolved_root)` (or `relative_to` try/except fallback).
- Return only the resolved safe path.

Also in `main()`, add a bounds check for `--schema` to avoid reading missing argv item.

No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
