### PR TITLE
Potential fix for code scanning alert no. 81: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/rsm-shim/rsm.py
+++ b/docs/resonance-substrate-model/rsm-shim/rsm.py
@@ -1,8 +1,14 @@
 import json
 import sys
+import os
 
 def load_config(path):
-    return json.load(open(path))
+    base_dir = os.path.dirname(os.path.realpath(__file__))
+    full_path = os.path.realpath(os.path.join(base_dir, path))
+    if os.path.commonpath([base_dir, full_path]) != base_dir:
+        raise ValueError("Config path is outside allowed directory")
+    with open(full_path) as f:
+        return json.load(f)
 
 def build_substrate(cfg):
     return {

--- a/docs/resonance-substrate-model/rsm-shim/rsm.py
+++ b/docs/resonance-substrate-model/rsm-shim/rsm.py
@@ -3,10 +3,18 @@ import sys
 import os
 
 def load_config(path):
+    if not isinstance(path, str) or not path.strip():
+        raise ValueError("Config path must be a non-empty string")
+    if not path.endswith(".json"):
+        raise ValueError("Config path must point to a .json file")
+
     base_dir = os.path.dirname(os.path.realpath(__file__))
     full_path = os.path.realpath(os.path.join(base_dir, path))
     if os.path.commonpath([base_dir, full_path]) != base_dir:
         raise ValueError("Config path is outside allowed directory")
+    if not os.path.isfile(full_path):
+        raise ValueError("Config path must point to an existing file")
+
     with open(full_path) as f:
         return json.load(f)
 

--- a/docs/resonance-substrate-model/rsm-shim/rsm.py
+++ b/docs/resonance-substrate-model/rsm-shim/rsm.py
@@ -1,12 +1,17 @@
 import json
 import sys
 import os
+import re
 
 def load_config(path):
     if not isinstance(path, str) or not path.strip():
         raise ValueError("Config path must be a non-empty string")
-    if not path.endswith(".json"):
-        raise ValueError("Config path must point to a .json file")
+    if os.path.isabs(path):
+        raise ValueError("Absolute config paths are not allowed")
+    if path != os.path.basename(path):
+        raise ValueError("Config path must be a filename without directories")
+    if not re.fullmatch(r"[A-Za-z0-9._-]+\.json", path):
+        raise ValueError("Config path must be a safe .json filename")
 
     base_dir = os.path.dirname(os.path.realpath(__file__))
     full_path = os.path.realpath(os.path.join(base_dir, path))


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/81](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/81)

The best fix is to canonicalize the user-provided path and enforce that it stays inside a trusted config root directory before opening it.

In `docs/resonance-substrate-model/rsm-shim/rsm.py`:
- Add `import os`.
- Define a safe base directory (here, the script directory via `os.path.dirname(os.path.realpath(__file__))`).
- In `load_config`, resolve the requested path with `os.path.realpath(os.path.join(base_dir, path))`.
- Reject paths that escape the base directory using `os.path.commonpath`.
- Open files using a context manager (`with open(...)`) after validation.

This preserves current functionality for relative config filenames near the script while preventing traversal/absolute path abuse.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
