### PR TITLE
Potential fix for code scanning alert no. 92: Uncontrolled data used in path expression

### DIFF
--- a/docs/starter/tools/validate.py
+++ b/docs/starter/tools/validate.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 from jsonschema import validate, ValidationError
 
@@ -6,21 +7,32 @@ def load_json(path):
     with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
 
+def safe_resolve_path(base_dir, user_path):
+    candidate = os.path.realpath(os.path.join(base_dir, user_path))
+    if os.path.commonpath([base_dir, candidate]) != base_dir:
+        raise ValueError(f"Path escapes allowed root: {user_path}")
+    return candidate
+
 def main():
     if len(sys.argv) != 2:
         print("Usage: python validate.py path/to/module.json")
         return
 
-    module_path = sys.argv[1]
-    schema_path = "../schema/module.schema.json"
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    project_root = os.path.realpath(os.path.join(script_dir, ".."))
 
     try:
+        module_path = safe_resolve_path(project_root, sys.argv[1])
+        schema_path = safe_resolve_path(project_root, "schema/module.schema.json")
+
         module_data = load_json(module_path)
         schema_data = load_json(schema_path)
 
         validate(instance=module_data, schema=schema_data)
         print("✔ module.json is valid and canon‑aligned.")
 
+    except ValueError as e:
+        print("✘ Invalid path:", e)
     except FileNotFoundError:
         print("✘ File not found. Check your paths.")
     except ValidationError as e:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/92](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/92)

To fix this, validate and canonicalize paths before opening files. The safest approach here is:

1. Resolve the script directory and define a trusted project root.
2. Convert user input into an absolute normalized path under that root.
3. Reject paths that escape the root (via `..` or absolute path tricks).
4. Use the same safe resolver for both `module_path` (user input) and `schema_path` (relative constant), then pass only validated absolute paths to `load_json`.

In `docs/starter/tools/validate.py`:
- Add `import os`.
- Add a helper `safe_resolve_path(base_dir, user_path)` that uses `os.path.realpath`, `os.path.join`, and `os.path.commonpath` to enforce containment.
- In `main()`, compute:
  - `script_dir = os.path.dirname(os.path.realpath(__file__))`
  - `project_root = os.path.realpath(os.path.join(script_dir, ".."))`
  - `module_path = safe_resolve_path(project_root, sys.argv[1])`
  - `schema_path = safe_resolve_path(project_root, "schema/module.schema.json")`
- Catch `ValueError` to report invalid/unsafe paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
