### PR TITLE
Potential fix for code scanning alert no. 62: Information exposure through an exception

### DIFF
--- a/docs/TFT_3Pack_v1.3/tft/entft/TFThooks/agents/scroll_runtime_trace_dashboard.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/TFThooks/agents/scroll_runtime_trace_dashboard.py
@@ -18,8 +18,9 @@ def dashboard():
     try:
         with open(TRACE_LOG_PATH, "r", encoding="utf-8") as f:
             data = json.load(f)["scroll_event_traces"]
-    except Exception as e:
-        return f"<h1>Error loading trace log: {e}</h1>"
+    except Exception:
+        app.logger.exception("Failed to load trace log for dashboard")
+        return "<h1>An internal error has occurred.</h1>", 500
 
     html = """
     <html>


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/62](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/62)

General fix: never include raw exception details in HTTP responses. Return a generic error message to users, and log the full exception details on the server for troubleshooting.

Best fix in this file:
- In `docs/TFT_3Pack_v1.3/tft/entft/TFThooks/agents/scroll_runtime_trace_dashboard.py`, update the `except` block in `dashboard()` so it:
  1. logs the exception using Flask’s app logger (`app.logger.exception(...)`), and
  2. returns a generic message with an HTTP 500 status code.
- No new third-party dependencies are needed.
- No import changes are required since `app` is already available and provides `logger`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
