### PR TITLE
Potential fix for code scanning alert no. 58: Flask app is run in debug mode

### DIFF
--- a/docs/scripts/vsoul_web_dashboard.py
+++ b/docs/scripts/vsoul_web_dashboard.py
@@ -117,4 +117,4 @@ def audits():
     return render_template_string(template, audits=audits)
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run()


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/58](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/58)

To fix this without changing core functionality, remove hardcoded debug mode and run with debugging disabled when the script starts directly. The most direct and reliable fix is to change:

- `app.run(debug=True)` → `app.run()`

Flask defaults `debug` to `False` unless explicitly enabled elsewhere, so this prevents the dangerous debugger from being exposed while preserving normal app startup behavior.

Change needed:
- **File:** `docs/scripts/vsoul_web_dashboard.py`
- **Region:** `if __name__ == "__main__":` block near lines 119–120
- **Edit:** replace the `app.run(debug=True)` call with `app.run()`

No new imports, methods, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
