### PR TITLE
Potential fix for code scanning alert no. 65: Uncontrolled data used in path expression

### DIFF
--- a/docs/TFT_3Pack_v1.3/tft/cli.py
+++ b/docs/TFT_3Pack_v1.3/tft/cli.py
@@ -3,6 +3,13 @@ from .nous import processor
 from .entft import encryptor
 from .tops import grid_ops
 
+def _validated_entft_output(value):
+    try:
+        encryptor._sanitize_output_path(value)
+        return value
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc))
+
 def main():
     parser = argparse.ArgumentParser(
         prog="tft",
@@ -19,7 +26,7 @@ def main():
     # 🔐 Encryption: entft
     enc_parser = subparsers.add_parser("entft", help="Encryption and badge trigger logic")
     enc_parser.add_argument("-i", required=True, help="Input file")
-    enc_parser.add_argument("-o", required=True, help="Output file")
+    enc_parser.add_argument("-o", required=True, type=_validated_entft_output, help="Output file")
     enc_parser.add_argument("-k", required=True, help="Key or glyphstream")
     enc_parser.add_argument("--basetype", default="decimal", help="Base lens for encryption overlays")
 

--- a/docs/TFT_3Pack_v1.3/tft/cli.py
+++ b/docs/TFT_3Pack_v1.3/tft/cli.py
@@ -5,8 +5,7 @@ from .tops import grid_ops
 
 def _validated_entft_output(value):
     try:
-        encryptor._sanitize_output_path(value)
-        return value
+        return encryptor._sanitize_output_path(value)
     except ValueError as exc:
         raise argparse.ArgumentTypeError(str(exc))
 

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -11,6 +11,25 @@ from datetime import datetime
 from pathlib import Path
 
 TRACE_LOG_PATH = Path("docs/_meta/entft_scroll_event_trace_registry.json")
+SAFE_OUTPUT_ROOT = Path("docs/_meta/entft_output")
+
+def _sanitize_output_path(output_path):
+    root = SAFE_OUTPUT_ROOT.resolve()
+    candidate = Path(output_path)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    candidate = candidate.resolve()
+
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        raise ValueError(f"Output path must stay within '{root}'")
+
+    if candidate.exists() and candidate.is_dir():
+        raise ValueError("Output path points to a directory, expected a file path")
+
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    return candidate
 
 def encrypt(input_path, output_path, key):
     print(f"[entft] 🔐 Encrypting {input_path} → {output_path} with key '{key}'...")
@@ -24,7 +43,8 @@ def encrypt(input_path, output_path, key):
 
     # Simulated encryption output
     encrypted = f"{resonance_hash[:32]}...{resonance_hash[-32:]}"
-    with open(output_path, "w", encoding="utf-8") as f:
+    safe_output_path = _sanitize_output_path(output_path)
+    with open(safe_output_path, "w", encoding="utf-8") as f:
         f.write(encrypted)
 
     # Log trace

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -15,9 +15,11 @@ SAFE_OUTPUT_ROOT = Path("docs/_meta/entft_output")
 
 def _sanitize_output_path(output_path):
     root = SAFE_OUTPUT_ROOT.resolve()
+    root.mkdir(parents=True, exist_ok=True)
 
     if isinstance(output_path, Path):
-        candidate = output_path.resolve()
+        requested = output_path
+        candidate = requested.resolve() if requested.is_absolute() else (root / requested).resolve()
         try:
             candidate.relative_to(root)
         except ValueError:

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -38,7 +38,7 @@ def _sanitize_output_path(output_path):
     except ValueError:
         raise ValueError(f"Output path must stay within '{root}'")
 
-    if candidate.exists() and candidate.is_symlink():
+    if candidate.is_symlink():
         raise ValueError("Output path must not be a symlink")
 
     if candidate.exists() and candidate.is_dir():
@@ -59,8 +59,11 @@ def encrypt(input_path, output_path, key):
     # Simulated encryption output
     encrypted = f"{resonance_hash[:32]}...{resonance_hash[-32:]}"
     safe_output_path = _sanitize_output_path(output_path)
-    with open(safe_output_path, "w", encoding="utf-8") as f:
-        f.write(encrypted)
+    try:
+        with open(safe_output_path, "x", encoding="utf-8") as f:
+            f.write(encrypted)
+    except FileExistsError:
+        raise ValueError(f"Output file already exists: '{safe_output_path}'")
 
     # Log trace
     trace_event = {

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -17,19 +17,6 @@ def _sanitize_output_path(output_path):
     root = SAFE_OUTPUT_ROOT.resolve()
     root.mkdir(parents=True, exist_ok=True)
 
-    if isinstance(output_path, Path):
-        requested = output_path
-        candidate = requested.resolve() if requested.is_absolute() else (root / requested).resolve()
-        try:
-            candidate.relative_to(root)
-        except ValueError:
-            raise ValueError(f"Output path must stay within '{root}'")
-        if candidate.is_symlink():
-            raise ValueError("Output path must not be a symlink")
-        if candidate.exists() and candidate.is_dir():
-            raise ValueError("Output path points to a directory, expected a file path")
-        return candidate
-
     raw_value = str(output_path)
     requested = Path(raw_value)
 

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -6,7 +6,7 @@ Encrypts scrolls using enTFT dual-layer logic:
 Logs symbolic fidelity and flame-grade echoes.
 """
 
-import hashlib, uuid, json
+import hashlib, uuid, json, re
 from datetime import datetime
 from pathlib import Path
 
@@ -18,26 +18,25 @@ def _sanitize_output_path(output_path):
     requested = Path(output_path)
 
     if requested.is_absolute():
-        raise ValueError("Output path must be relative to the safe output root")
+        raise ValueError("Output path must be a filename relative to the safe output root")
 
-    if not requested.parts or requested == Path("."):
-        raise ValueError("Output path must not be empty")
+    filename = requested.name
+    if not filename or filename in {".", ".."}:
+        raise ValueError("Output filename must not be empty")
 
-    if any(part == ".." for part in requested.parts):
-        raise ValueError("Output path must not contain parent directory traversal segments")
+    if str(requested) != filename:
+        raise ValueError("Output path must be a filename only (no directory components)")
 
-    candidate = (root / requested).resolve()
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", filename):
+        raise ValueError("Output filename contains invalid characters")
+
+    root.mkdir(parents=True, exist_ok=True)
+    candidate = (root / filename).resolve()
 
     try:
         candidate.relative_to(root)
     except ValueError:
         raise ValueError(f"Output path must stay within '{root}'")
-
-    for parent in reversed(candidate.parents):
-        if parent == root:
-            break
-        if parent.exists() and parent.is_symlink():
-            raise ValueError("Output path must not traverse symlinked directories")
 
     if candidate.exists() and candidate.is_symlink():
         raise ValueError("Output path must not be a symlink")
@@ -45,7 +44,6 @@ def _sanitize_output_path(output_path):
     if candidate.exists() and candidate.is_dir():
         raise ValueError("Output path points to a directory, expected a file path")
 
-    candidate.parent.mkdir(parents=True, exist_ok=True)
     return candidate
 
 def encrypt(input_path, output_path, key):

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -15,28 +15,29 @@ SAFE_OUTPUT_ROOT = Path("docs/_meta/entft_output")
 
 def _sanitize_output_path(output_path):
     root = SAFE_OUTPUT_ROOT.resolve()
-    requested = Path(output_path)
+    raw_value = str(output_path)
+    requested = Path(raw_value)
 
     if requested.is_absolute():
         raise ValueError("Output path must be a filename relative to the safe output root")
 
-    root.mkdir(parents=True, exist_ok=True)
-    candidate = (root / requested).resolve()
-
-    try:
-        candidate.relative_to(root)
-    except ValueError:
-        raise ValueError(f"Output path must stay within '{root}'")
-
-    if requested.parent != Path("."):
+    filename = requested.name
+    if raw_value != filename:
         raise ValueError("Output path must be a filename only (no directory components)")
 
-    filename = requested.name
     if not filename or filename in {".", ".."}:
         raise ValueError("Output filename must not be empty")
 
     if not re.fullmatch(r"[A-Za-z0-9._-]+", filename):
         raise ValueError("Output filename contains invalid characters")
+
+    root.mkdir(parents=True, exist_ok=True)
+    candidate = (root / filename).resolve()
+
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        raise ValueError(f"Output path must stay within '{root}'")
 
     if candidate.is_symlink():
         raise ValueError("Output path must not be a symlink")

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -20,23 +20,23 @@ def _sanitize_output_path(output_path):
     if requested.is_absolute():
         raise ValueError("Output path must be a filename relative to the safe output root")
 
-    filename = requested.name
-    if not filename or filename in {".", ".."}:
-        raise ValueError("Output filename must not be empty")
-
-    if str(requested) != filename:
-        raise ValueError("Output path must be a filename only (no directory components)")
-
-    if not re.fullmatch(r"[A-Za-z0-9._-]+", filename):
-        raise ValueError("Output filename contains invalid characters")
-
     root.mkdir(parents=True, exist_ok=True)
-    candidate = (root / filename).resolve()
+    candidate = (root / requested).resolve()
 
     try:
         candidate.relative_to(root)
     except ValueError:
         raise ValueError(f"Output path must stay within '{root}'")
+
+    if requested.parent != Path("."):
+        raise ValueError("Output path must be a filename only (no directory components)")
+
+    filename = requested.name
+    if not filename or filename in {".", ".."}:
+        raise ValueError("Output filename must not be empty")
+
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", filename):
+        raise ValueError("Output filename contains invalid characters")
 
     if candidate.is_symlink():
         raise ValueError("Output path must not be a symlink")

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -16,9 +16,11 @@ SAFE_OUTPUT_ROOT = Path("docs/_meta/entft_output")
 def _sanitize_output_path(output_path):
     root = SAFE_OUTPUT_ROOT.resolve()
     candidate = Path(output_path)
-    if not candidate.is_absolute():
-        candidate = root / candidate
-    candidate = candidate.resolve()
+
+    if candidate.is_absolute():
+        raise ValueError("Output path must be relative to the safe output root")
+
+    candidate = (root / candidate).resolve()
 
     try:
         candidate.relative_to(root)

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -20,12 +20,21 @@ def _sanitize_output_path(output_path):
     if candidate.is_absolute():
         raise ValueError("Output path must be relative to the safe output root")
 
+    if not candidate.parts or candidate == Path("."):
+        raise ValueError("Output path must not be empty")
+
+    if any(part == ".." for part in candidate.parts):
+        raise ValueError("Output path must not contain parent directory traversal segments")
+
     candidate = (root / candidate).resolve()
 
     try:
         candidate.relative_to(root)
     except ValueError:
         raise ValueError(f"Output path must stay within '{root}'")
+
+    if candidate.exists() and candidate.is_symlink():
+        raise ValueError("Output path must not be a symlink")
 
     if candidate.exists() and candidate.is_dir():
         raise ValueError("Output path points to a directory, expected a file path")

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -15,23 +15,29 @@ SAFE_OUTPUT_ROOT = Path("docs/_meta/entft_output")
 
 def _sanitize_output_path(output_path):
     root = SAFE_OUTPUT_ROOT.resolve()
-    candidate = Path(output_path)
+    requested = Path(output_path)
 
-    if candidate.is_absolute():
+    if requested.is_absolute():
         raise ValueError("Output path must be relative to the safe output root")
 
-    if not candidate.parts or candidate == Path("."):
+    if not requested.parts or requested == Path("."):
         raise ValueError("Output path must not be empty")
 
-    if any(part == ".." for part in candidate.parts):
+    if any(part == ".." for part in requested.parts):
         raise ValueError("Output path must not contain parent directory traversal segments")
 
-    candidate = (root / candidate).resolve()
+    candidate = (root / requested).resolve()
 
     try:
         candidate.relative_to(root)
     except ValueError:
         raise ValueError(f"Output path must stay within '{root}'")
+
+    for parent in reversed(candidate.parents):
+        if parent == root:
+            break
+        if parent.exists() and parent.is_symlink():
+            raise ValueError("Output path must not traverse symlinked directories")
 
     if candidate.exists() and candidate.is_symlink():
         raise ValueError("Output path must not be a symlink")

--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -15,6 +15,19 @@ SAFE_OUTPUT_ROOT = Path("docs/_meta/entft_output")
 
 def _sanitize_output_path(output_path):
     root = SAFE_OUTPUT_ROOT.resolve()
+
+    if isinstance(output_path, Path):
+        candidate = output_path.resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError:
+            raise ValueError(f"Output path must stay within '{root}'")
+        if candidate.is_symlink():
+            raise ValueError("Output path must not be a symlink")
+        if candidate.exists() and candidate.is_dir():
+            raise ValueError("Output path points to a directory, expected a file path")
+        return candidate
+
     raw_value = str(output_path)
     requested = Path(raw_value)
 


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/65](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/65)

To fix this safely without changing intended encryption behavior, validate and constrain the output path before opening it. The best approach here is to canonicalize (`resolve`) the user-provided path and enforce that it stays inside a dedicated safe output directory. Also reject directory targets.

**Edits to apply in `docs/TFT_3Pack_v1.3/tft/entft/encryptor.py`:**
1. Add a constant safe root directory (for example `docs/_meta/entft_output`).
2. Add a helper function to:
   - resolve the safe root and candidate path,
   - join relative inputs under the safe root,
   - ensure the resolved path is within safe root (`relative_to` check),
   - reject directory paths,
   - create parent directories as needed.
3. Use the sanitized path in `encrypt` for the write operation instead of raw `output_path`.

No dependency changes are required; `pathlib` is already in use.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
