### PR TITLE
Potential fix for code scanning alert no. 111: Uncontrolled data used in path expression

### DIFF
--- a/docs/starter/tools/validate.py
+++ b/docs/starter/tools/validate.py
@@ -8,9 +8,12 @@ def load_json(path):
         return json.load(f)
 
 def safe_resolve_path(base_dir, user_path):
-    candidate = os.path.realpath(os.path.join(base_dir, user_path))
-    if os.path.commonpath([base_dir, candidate]) != base_dir:
+    safe_base = os.path.realpath(base_dir)
+    candidate = os.path.realpath(os.path.join(safe_base, user_path))
+    if os.path.commonpath([safe_base, candidate]) != safe_base:
         raise ValueError(f"Path escapes allowed root: {user_path}")
+    if os.path.splitext(candidate)[1].lower() != ".json":
+        raise ValueError(f"Only .json files are allowed: {user_path}")
     return candidate
 
 def main():


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/111](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/111)

Use strict path validation in `safe_resolve_path` so that all user-provided paths are canonicalized and constrained to a canonical root directory, and additionally restrict accepted files to `.json` to match program behavior.

Best fix in this file:
- In `safe_resolve_path`:
  - Canonicalize `base_dir` with `os.path.realpath`.
  - Build candidate with that canonical root.
  - Keep/strengthen the containment check using `os.path.commonpath`.
  - Reject non-`.json` targets.
- In `main`, no behavioral change is needed beyond using the improved sanitizer already in place.

This keeps existing functionality (validate a user-specified module JSON against a schema) while reducing traversal/symlink edge cases and making the path safety intent explicit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
