### PR TITLE
Potential fix for code scanning alert no. 111: Uncontrolled data used in path expression

### DIFF
--- a/docs/starter/tools/validate.py
+++ b/docs/starter/tools/validate.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from pathlib import Path
 from jsonschema import validate, ValidationError
 
 def load_json(path):
@@ -8,13 +9,20 @@ def load_json(path):
         return json.load(f)
 
 def safe_resolve_path(base_dir, user_path):
-    safe_base = os.path.realpath(base_dir)
-    candidate = os.path.realpath(os.path.join(safe_base, user_path))
-    if os.path.commonpath([safe_base, candidate]) != safe_base:
+    safe_base = Path(base_dir).resolve()
+    user_rel = Path(user_path)
+    if user_rel.is_absolute():
+        raise ValueError(f"Absolute paths are not allowed: {user_path}")
+
+    candidate = (safe_base / user_rel).resolve()
+    try:
+        candidate.relative_to(safe_base)
+    except ValueError:
         raise ValueError(f"Path escapes allowed root: {user_path}")
-    if os.path.splitext(candidate)[1].lower() != ".json":
+
+    if candidate.suffix.lower() != ".json":
         raise ValueError(f"Only .json files are allowed: {user_path}")
-    return candidate
+    return str(candidate)
 
 def main():
     if len(sys.argv) != 2:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/111](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/111)

Use a strict “resolve-and-verify-under-root” approach with `pathlib.Path` and reject absolute user input paths explicitly. This keeps the same functionality (allow relative JSON paths under project root) while making the trust boundary clearer.

Best fix in `docs/starter/tools/validate.py`:
1. Import `Path` from `pathlib`.
2. In `safe_resolve_path`:
   - Resolve `base_dir` to an absolute canonical root.
   - Parse `user_path` as a `Path` and reject if absolute.
   - Resolve `(safe_base / user_path)` to canonical absolute path.
   - Enforce containment with `candidate.relative_to(safe_base)` (raises if outside root).
   - Keep `.json` extension check.
   - Return `str(candidate)` to preserve existing `open()` usage.

This is a targeted change only in the shown file and does not alter CLI behavior except making path validation stricter and clearer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
