### PR TITLE
Potential fix for code scanning alert no. 131: Uncontrolled data used in path expression

### DIFF
--- a/docs/starter/tools/validate.py
+++ b/docs/starter/tools/validate.py
@@ -10,9 +10,15 @@ def load_json(path):
 
 def safe_resolve_path(base_dir, user_path):
     safe_base = Path(base_dir).resolve()
+    user_path = str(user_path).strip()
     user_rel = Path(user_path)
+
+    if not user_path:
+        raise ValueError("Path must not be empty")
     if user_rel.is_absolute():
         raise ValueError(f"Absolute paths are not allowed: {user_path}")
+    if ".." in user_rel.parts:
+        raise ValueError(f"Path traversal is not allowed: {user_path}")
 
     candidate = (safe_base / user_rel).resolve()
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/131](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/131)

General fix: sanitize and validate untrusted path input before any path composition, then enforce canonical containment after resolution.

Best concrete fix in `docs/starter/tools/validate.py`:
- In `safe_resolve_path`, normalize `user_path` as a string first.
- Reject empty paths and traversal components (`..`) explicitly using `Path(user_path).parts` before joining.
- Keep existing absolute-path rejection, canonical resolution, base containment check, and `.json` suffix restriction.
- This preserves current functionality (valid relative JSON paths under project root still work) while making the validation stricter and clearer to static analysis.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
