### PR TITLE
Potential fix for code scanning alert no. 109: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/rsm-shim/rsm.py
+++ b/docs/resonance-substrate-model/rsm-shim/rsm.py
@@ -13,8 +13,15 @@ def load_config(path):
     if not re.fullmatch(r"[A-Za-z0-9._-]+\.json", path):
         raise ValueError("Config path must be a safe .json filename")
 
+    allowed_configs = {
+        "config.json": "config.json"
+    }
+    if path not in allowed_configs:
+        raise ValueError("Config path is not in the allowed config list")
+
     base_dir = os.path.dirname(os.path.realpath(__file__))
-    full_path = os.path.realpath(os.path.join(base_dir, path))
+    safe_name = allowed_configs[path]
+    full_path = os.path.realpath(os.path.join(base_dir, safe_name))
     if os.path.commonpath([base_dir, full_path]) != base_dir:
         raise ValueError("Config path is outside allowed directory")
     if not os.path.isfile(full_path):


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/109](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/109)

General fix: avoid using raw user input directly in path expressions. Instead, resolve user input to a known-safe value (allowlist key → fixed filename), then build the path from trusted constants only.

Best fix here (without changing overall functionality style): in `docs/resonance-substrate-model/rsm-shim/rsm.py`, keep existing checks, but add a small allowlist mapping and require the input filename to be one of those allowed entries before building `full_path`. This ensures filesystem access is limited to explicitly approved config files in the script directory.

Changes needed:
- In `load_config`, define an `allowed_configs` mapping/set after validation.
- Validate `path` membership in `allowed_configs`.
- Build `full_path` using the mapped trusted filename (not raw `path`).
- Keep existing `realpath/commonpath/isfile/open` checks.

No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
