### PR TITLE
Potential fix for code scanning alert no. 59: Flask app is run in debug mode

### DIFF
--- a/docs/scripts/vsoul_web_explorer.py
+++ b/docs/scripts/vsoul_web_explorer.py
@@ -150,4 +150,4 @@ def audit_detail(audit_id):
     return render_template_string(template, audit=audit)
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=False)


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/59](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/59)

To fix this, disable Flask debug mode in the `app.run(...)` call so the interactive debugger cannot be exposed.

Best single change without altering app functionality: update the startup line in `docs/scripts/vsoul_web_explorer.py` from `app.run(debug=True)` to `app.run(debug=False)`. This preserves direct script execution and server behavior while removing debugger exposure.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
