### PR TITLE
Potential fix for code scanning alert no. 73: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/tools/cli/inspect_schema.py
+++ b/docs/resonance-substrate-model/tools/cli/inspect_schema.py
@@ -39,6 +39,21 @@ def error(msg):
     sys.exit(1)
 
 
+def validate_schema_path(user_input: str) -> Path:
+    # Restrict schema inspection to files under docs/resonance-substrate-model
+    safe_root = Path(__file__).resolve().parents[2]
+    candidate = Path(user_input).expanduser()
+    candidate = candidate if candidate.is_absolute() else (Path.cwd() / candidate)
+    resolved = candidate.resolve(strict=False)
+
+    try:
+        resolved.relative_to(safe_root)
+    except ValueError:
+        error(f"Path is outside allowed directory: {safe_root}")
+
+    return resolved
+
+
 # ------------------------------------------------------------
 # Inspection Logic
 # ------------------------------------------------------------
@@ -85,7 +100,7 @@ def main():
         print("Usage: python inspect_schema.py path/to/schema.json")
         sys.exit(1)
 
-    path = Path(sys.argv[1])
+    path = validate_schema_path(sys.argv[1])
     if not path.exists():
         error(f"Schema file not found: {path}")
 

--- a/docs/resonance-substrate-model/tools/cli/inspect_schema.py
+++ b/docs/resonance-substrate-model/tools/cli/inspect_schema.py
@@ -41,7 +41,7 @@ def error(msg):
 
 def validate_schema_path(user_input: str) -> Path:
     # Restrict schema inspection to files under docs/resonance-substrate-model
-    safe_root = Path(__file__).resolve().parents[2]
+    safe_root = Path(__file__).resolve().parents[1]
     candidate = Path(user_input).expanduser()
     candidate = candidate if candidate.is_absolute() else (Path.cwd() / candidate)
     resolved = candidate.resolve(strict=False)
@@ -50,6 +50,9 @@ def validate_schema_path(user_input: str) -> Path:
         resolved.relative_to(safe_root)
     except ValueError:
         error(f"Path is outside allowed directory: {safe_root}")
+
+    if resolved.suffix.lower() != ".json":
+        error("Schema path must point to a .json file")
 
     return resolved
 


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/73](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/73)

Use a safe base directory and ensure the user-provided path resolves within it before any filesystem use.

Best fix here:
- In `docs/resonance-substrate-model/tools/cli/inspect_schema.py`, add a helper that:
  - resolves a trusted root (for this script, the repository `docs/resonance-substrate-model` directory),
  - resolves the candidate user path to an absolute canonical path,
  - rejects it unless it is within the trusted root (using `relative_to` check).
- In `main()`, replace direct `Path(sys.argv[1])` usage with validated path from that helper.
- Keep functionality the same otherwise (still reads schema JSON and prints summary).

No new dependencies are needed; `pathlib` already supports secure canonicalization checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
