### PR TITLE
Potential fix for code scanning alert no. 74: Uncontrolled data used in path expression

### DIFF
--- a/docs/rtt/guild/Little_Science_Series/ingest.py
+++ b/docs/rtt/guild/Little_Science_Series/ingest.py
@@ -83,10 +83,22 @@ def resolve_within_base(user_value: str, base_dir: pathlib.Path, label: str) -> 
     """Resolve a user-provided path and ensure it stays within base_dir."""
     base_resolved = base_dir.resolve()
     candidate = pathlib.Path(user_value)
+
+    if not user_value or user_value.strip() == "":
+        print(f"\n  ❌  Unsafe {label} path: {user_value!r}")
+        print(f"      {label} cannot be empty and must be within: {base_resolved}\n")
+        sys.exit(1)
+
+    if user_value.startswith("~") or ".." in candidate.parts:
+        print(f"\n  ❌  Unsafe {label} path: {user_value}")
+        print(f"      {label} must not use '~' or '..' segments.\n")
+        sys.exit(1)
+
     if candidate.is_absolute():
         print(f"\n  ❌  Unsafe {label} path: {user_value}")
         print(f"      {label} must be a relative path within: {base_resolved}\n")
         sys.exit(1)
+
     resolved = (base_resolved / candidate).resolve()
     try:
         resolved.relative_to(base_resolved)

--- a/docs/rtt/guild/Little_Science_Series/ingest.py
+++ b/docs/rtt/guild/Little_Science_Series/ingest.py
@@ -79,6 +79,19 @@ DONE_FILE        = "queue_done.jsonl"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
+def resolve_within_base(user_value: str, base_dir: pathlib.Path, label: str) -> pathlib.Path:
+    """Resolve a user-provided path and ensure it stays within base_dir."""
+    candidate = pathlib.Path(user_value)
+    resolved = candidate.resolve() if candidate.is_absolute() else (base_dir / candidate).resolve()
+    try:
+        resolved.relative_to(base_dir)
+    except ValueError:
+        print(f"\n  ❌  Unsafe {label} path: {user_value}")
+        print(f"      {label} must stay within: {base_dir}\n")
+        sys.exit(1)
+    return resolved
+
+
 def load_json(path: pathlib.Path) -> object:
     """Open a JSON file; exit with a clear message on failure."""
     if not path.exists():
@@ -189,7 +202,8 @@ def main() -> None:
     parser.add_argument("--type",     choices=["STILL", "ANIM"])
     args = parser.parse_args()
 
-    output_root = pathlib.Path(args.output)
+    base_dir = pathlib.Path(__file__).resolve().parent
+    output_root = resolve_within_base(args.output, base_dir, "output")
     dry_run     = args.dry_run
 
     print("\n" + "═" * 60)
@@ -198,8 +212,10 @@ def main() -> None:
     if dry_run:
         print("  ⚠  DRY-RUN — no files will be written\n")
 
-    manifest = load_json(pathlib.Path(args.manifest))
-    schema   = load_json(pathlib.Path(args.schema))
+    manifest_path = resolve_within_base(args.manifest, base_dir, "manifest")
+    schema_path   = resolve_within_base(args.schema, base_dir, "schema")
+    manifest = load_json(manifest_path)
+    schema   = load_json(schema_path)
 
     print("  🔍 Validating …")
     errors = validate_manifest(manifest, schema)

--- a/docs/rtt/guild/Little_Science_Series/ingest.py
+++ b/docs/rtt/guild/Little_Science_Series/ingest.py
@@ -81,13 +81,18 @@ DONE_FILE        = "queue_done.jsonl"
 
 def resolve_within_base(user_value: str, base_dir: pathlib.Path, label: str) -> pathlib.Path:
     """Resolve a user-provided path and ensure it stays within base_dir."""
+    base_resolved = base_dir.resolve()
     candidate = pathlib.Path(user_value)
-    resolved = candidate.resolve() if candidate.is_absolute() else (base_dir / candidate).resolve()
+    if candidate.is_absolute():
+        print(f"\n  ❌  Unsafe {label} path: {user_value}")
+        print(f"      {label} must be a relative path within: {base_resolved}\n")
+        sys.exit(1)
+    resolved = (base_resolved / candidate).resolve()
     try:
-        resolved.relative_to(base_dir)
+        resolved.relative_to(base_resolved)
     except ValueError:
         print(f"\n  ❌  Unsafe {label} path: {user_value}")
-        print(f"      {label} must stay within: {base_dir}\n")
+        print(f"      {label} must stay within: {base_resolved}\n")
         sys.exit(1)
     return resolved
 


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/74](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/74)

Use a **safe base-directory containment check** before any filesystem access for user-provided paths (`--manifest`, `--schema`, and optionally `--output`), by resolving the candidate path and ensuring it stays inside an allowed root (the script directory). This preserves existing functionality for normal relative file use while blocking traversal/absolute-path escapes.

Best fix in this file:
1. Add a helper (e.g., `resolve_within_base(user_value: str, base_dir: pathlib.Path, label: str) -> pathlib.Path`) that:
   - Builds `(base_dir / user_value).resolve()` (or resolves absolute as-is then checks),
   - Verifies the resolved path is within `base_dir` using `relative_to`,
   - Exits with a clear error if outside.
2. In `main`, compute `base_dir = pathlib.Path(__file__).resolve().parent`.
3. Replace direct `pathlib.Path(args.manifest)` / `pathlib.Path(args.schema)` / `pathlib.Path(args.output)` with validated paths from the helper.
4. Keep `load_json()` logic unchanged except that it now receives prevalidated paths.

This requires no new dependencies and only edits in `docs/rtt/guild/Little_Science_Series/ingest.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
