### PR TITLE
Potential fix for code scanning alert no. 77: Uncontrolled data used in path expression

### DIFF
--- a/docs/rtt/guild/Little_Science_Series/ingest.py
+++ b/docs/rtt/guild/Little_Science_Series/ingest.py
@@ -55,6 +55,7 @@ AI pipeline contract (for automated agents)
 import argparse
 import json
 import pathlib
+import re
 import sys
 import textwrap
 
@@ -146,13 +147,24 @@ def scene_folder_name(scene_number: int, scene_name: str) -> str:
     return f"S{scene_number:02d}_{scene_name.replace(' ', '_').replace('/', '-')}"
 
 
+_SAFE_COMPONENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _safe_path_component(value: object, field_name: str) -> str:
+    component = pathlib.PurePath(str(value)).name
+    if component in {"", ".", ".."} or not _SAFE_COMPONENT_RE.fullmatch(component):
+        raise ValueError(f"Unsafe {field_name} in manifest entry: {value!r}")
+    return component
+
+
 def build_output_path(entry: dict, output_root: pathlib.Path) -> pathlib.Path:
     """output/<book_name>/S##_<scene_name>/<filename>"""
-    safe_book = pathlib.PurePath(str(entry["book_name"])).name
-    safe_scene = pathlib.PurePath(
-        scene_folder_name(entry["scene_number"], entry["scene_name"])
-    ).name
-    safe_filename = pathlib.PurePath(str(entry["filename"])).name
+    safe_book = _safe_path_component(entry["book_name"], "book_name")
+    safe_scene = _safe_path_component(
+        scene_folder_name(entry["scene_number"], entry["scene_name"]),
+        "scene_name",
+    )
+    safe_filename = _safe_path_component(entry["filename"], "filename")
 
     base_dir = pathlib.Path(__file__).resolve().parent
     root = output_root.resolve()

--- a/docs/rtt/guild/Little_Science_Series/ingest.py
+++ b/docs/rtt/guild/Little_Science_Series/ingest.py
@@ -154,7 +154,13 @@ def build_output_path(entry: dict, output_root: pathlib.Path) -> pathlib.Path:
     ).name
     safe_filename = pathlib.PurePath(str(entry["filename"])).name
 
+    base_dir = pathlib.Path(__file__).resolve().parent
     root = output_root.resolve()
+    try:
+        root.relative_to(base_dir)
+    except ValueError:
+        raise ValueError(f"Unsafe output root outside base directory: {output_root!r}")
+
     candidate = (root / safe_book / safe_scene / safe_filename).resolve()
     try:
         candidate.relative_to(root)

--- a/docs/rtt/guild/Little_Science_Series/ingest.py
+++ b/docs/rtt/guild/Little_Science_Series/ingest.py
@@ -148,12 +148,19 @@ def scene_folder_name(scene_number: int, scene_name: str) -> str:
 
 def build_output_path(entry: dict, output_root: pathlib.Path) -> pathlib.Path:
     """output/<book_name>/S##_<scene_name>/<filename>"""
-    return (
-        output_root
-        / entry["book_name"]
-        / scene_folder_name(entry["scene_number"], entry["scene_name"])
-        / entry["filename"]
-    )
+    safe_book = pathlib.PurePath(str(entry["book_name"])).name
+    safe_scene = pathlib.PurePath(
+        scene_folder_name(entry["scene_number"], entry["scene_name"])
+    ).name
+    safe_filename = pathlib.PurePath(str(entry["filename"])).name
+
+    root = output_root.resolve()
+    candidate = (root / safe_book / safe_scene / safe_filename).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        raise ValueError(f"Unsafe output path derived from manifest entry: {entry!r}")
+    return candidate
 
 
 def ensure_folder(file_path: pathlib.Path, dry_run: bool) -> None:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/77](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/77)

Use a **safe-join + containment check** when building output file paths from manifest fields, and sanitize path components to filenames only (drop any directory elements). The best minimal fix here is:

1. In `build_output_path`, sanitize `book_name`, scene folder name, and `filename` using `pathlib.PurePath(...).name` so user-controlled values cannot inject path separators or absolute paths.
2. Build a candidate path and resolve it.
3. Verify the resolved path is still under the resolved `output_root` (using `relative_to` in a `try/except`).
4. Abort with a clear error if unsafe.

This keeps existing behavior (same folder structure intent) while preventing traversal in both placeholder writing and any downstream queue output path usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
