### PR TITLE
Potential fix for code scanning alert no. 132: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/tools/cli/inspect_schema.py
+++ b/docs/resonance-substrate-model/tools/cli/inspect_schema.py
@@ -41,7 +41,7 @@ def error(msg):
 
 def validate_schema_path(user_input: str) -> Path:
     # Restrict schema inspection to files under docs/resonance-substrate-model
-    safe_root = Path(__file__).resolve().parents[1]
+    safe_root = Path(__file__).resolve().parents[1].resolve()
     candidate = Path(user_input).expanduser()
     candidate = candidate if candidate.is_absolute() else (Path.cwd() / candidate)
     resolved = candidate.resolve(strict=False)
@@ -53,6 +53,12 @@ def validate_schema_path(user_input: str) -> Path:
 
     if resolved.suffix.lower() != ".json":
         error("Schema path must point to a .json file")
+
+    if not resolved.exists():
+        error(f"Schema file not found: {resolved}")
+
+    if not resolved.is_file():
+        error(f"Schema path must be a regular file: {resolved}")
 
     return resolved
 
@@ -104,9 +110,6 @@ def main():
         sys.exit(1)
 
     path = validate_schema_path(sys.argv[1])
-    if not path.exists():
-        error(f"Schema file not found: {path}")
-
     inspect_schema(path)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/132](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/132)

General fix approach: keep accepting a user path, but canonicalize both the allowed root and candidate path, enforce containment after canonicalization, and reject unsafe file types before opening.

Best targeted fix in `docs/resonance-substrate-model/tools/cli/inspect_schema.py`:
- In `validate_schema_path`:
  - Canonicalize `safe_root` with `.resolve()`.
  - Build candidate from user input, resolve it, and keep the `relative_to` containment check.
  - Keep `.json` suffix validation.
  - Add checks to ensure the resolved path exists and is a regular file (not directory/device/etc.).
- In `main`:
  - Remove redundant `path.exists()` check since existence is now enforced in `validate_schema_path`.

No new dependencies are needed; `pathlib` already provides required APIs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
