### PR TITLE
Potential fix for code scanning alert no. 75: Uncontrolled data used in path expression

### DIFF
--- a/docs/rtt/guild/Little_Science_Series/ingest.py
+++ b/docs/rtt/guild/Little_Science_Series/ingest.py
@@ -113,6 +113,11 @@ def resolve_json_filename(user_value: str, base_dir: pathlib.Path, label: str) -
         print(f"      {label} must end with .json.\n")
         sys.exit(1)
 
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+\.json", candidate.name):
+        print(f"\n  ❌  Unsafe {label} path: {user_value}")
+        print(f"      {label} may contain only letters, numbers, '.', '_' or '-', and must end with .json.\n")
+        sys.exit(1)
+
     resolved = (base_resolved / candidate.name).resolve()
     return _assert_within_base(resolved, base_resolved, label)
 

--- a/docs/rtt/guild/Little_Science_Series/ingest.py
+++ b/docs/rtt/guild/Little_Science_Series/ingest.py
@@ -93,6 +93,30 @@ def _assert_within_base(path_value: pathlib.Path, base_dir: pathlib.Path, label:
     return resolved
 
 
+def resolve_json_filename(user_value: str, base_dir: pathlib.Path, label: str) -> pathlib.Path:
+    """Resolve a filename-only JSON argument within base_dir."""
+    base_resolved = base_dir.resolve()
+    candidate = pathlib.Path(user_value)
+
+    if not user_value or user_value.strip() == "":
+        print(f"\n  ❌  Unsafe {label} path: {user_value!r}")
+        print(f"      {label} cannot be empty and must be a .json filename in: {base_resolved}\n")
+        sys.exit(1)
+
+    if candidate.name != user_value or candidate.parent != pathlib.Path("."):
+        print(f"\n  ❌  Unsafe {label} path: {user_value}")
+        print(f"      {label} must be a filename only (no folders).\n")
+        sys.exit(1)
+
+    if candidate.suffix.lower() != ".json":
+        print(f"\n  ❌  Unsafe {label} path: {user_value}")
+        print(f"      {label} must end with .json.\n")
+        sys.exit(1)
+
+    resolved = (base_resolved / candidate.name).resolve()
+    return _assert_within_base(resolved, base_resolved, label)
+
+
 def resolve_within_base(user_value: str, base_dir: pathlib.Path, label: str) -> pathlib.Path:
     """Resolve a user-provided path and ensure it stays within base_dir."""
     base_resolved = base_dir.resolve()
@@ -262,8 +286,8 @@ def main() -> None:
     if dry_run:
         print("  ⚠  DRY-RUN — no files will be written\n")
 
-    manifest_path = resolve_within_base(args.manifest, base_dir, "manifest")
-    schema_path   = resolve_within_base(args.schema, base_dir, "schema")
+    manifest_path = resolve_json_filename(args.manifest, base_dir, "manifest")
+    schema_path   = resolve_json_filename(args.schema, base_dir, "schema")
     manifest = load_json(manifest_path)
     schema   = load_json(schema_path)
 


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/75](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/75)

Use a stricter validation policy for the JSON config inputs (`--manifest`, `--schema`) so they cannot be arbitrary relative paths at all. The safest minimal-change fix is:

1. Keep existing containment logic for `--output` (it is expected to be user-selectable).
2. For `--manifest` and `--schema`, require **filename-only** values (no directory components), restrict to `.json`, and then resolve against `base_dir`.
3. Continue using `load_json(pathlib.Path)` unchanged; now the provided path is constrained to a safe set of local files in the script directory.

In `docs/rtt/guild/Little_Science_Series/ingest.py`:
- Add a new helper (near existing path helpers) to validate filename-only JSON arguments and return `(base_dir / filename).resolve()`.
- Replace lines where `manifest_path` and `schema_path` are computed to use this stricter helper instead of `resolve_within_base`.

No new third-party dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
