### PR TITLE
Potential fix for code scanning alert no. 100: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/tools/cli/validate.py
+++ b/docs/resonance-substrate-model/tools/cli/validate.py
@@ -171,14 +171,7 @@ def validate_manifest(manifest_path: Path, repo_root: Path):
             error("Manifest entry 'file' field must be a string")
 
         raw_schema_path = Path(entry["file"])
-        if raw_schema_path.is_absolute():
-            error(f"Schema path must be relative to manifest directory: {raw_schema_path}")
-
-        schema_path = (manifest_dir / raw_schema_path).resolve()
-        try:
-            schema_path.relative_to(manifest_dir)
-        except ValueError:
-            error(f"Schema path escapes manifest directory: {raw_schema_path}")
+        schema_path = ensure_within_root(raw_schema_path, manifest_dir, "Schema path")
 
         if not schema_path.exists():
             error(f"Schema listed in manifest not found: {schema_path}")


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/100](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/100)

Use the existing `ensure_within_root` sanitizer on each manifest `entry["file"]` before any path join/resolve logic, with `manifest_dir` as the root. This keeps behavior the same (schema paths must remain under the manifest directory) while making validation explicit and eliminating the tainted path construction pattern at line 177.

**Best single fix (in `docs/resonance-substrate-model/tools/cli/validate.py`, inside `validate_manifest`)**:
- Replace manual absolute-path + resolve + `relative_to` checks for `raw_schema_path` with:
  - `raw_schema_path = Path(entry["file"])`
  - `schema_path = ensure_within_root(raw_schema_path, manifest_dir, "Schema path")`
- Keep the existing existence check and error reporting.
- No new imports or dependencies are required (all needed modules are already present).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
