### PR TITLE
Potential fix for code scanning alert no. 149: Uncontrolled data used in path expression

### DIFF
--- a/docs/rtt/guild/Little_Science_Series/ingest.py
+++ b/docs/rtt/guild/Little_Science_Series/ingest.py
@@ -96,14 +96,16 @@ def _assert_within_base(path_value: pathlib.Path, base_dir: pathlib.Path, label:
 def resolve_within_base(user_value: str, base_dir: pathlib.Path, label: str) -> pathlib.Path:
     """Resolve a user-provided path and ensure it stays within base_dir."""
     base_resolved = base_dir.resolve()
-    candidate = pathlib.Path(user_value)
 
     if not user_value or user_value.strip() == "":
         print(f"\n  ❌  Unsafe {label} path: {user_value!r}")
         print(f"      {label} cannot be empty and must be within: {base_resolved}\n")
         sys.exit(1)
 
-    if user_value.startswith("~") or ".." in candidate.parts:
+    normalized_input = user_value.strip()
+    candidate = pathlib.Path(normalized_input)
+
+    if normalized_input.startswith("~") or ".." in candidate.parts:
         print(f"\n  ❌  Unsafe {label} path: {user_value}")
         print(f"      {label} must not use '~' or '..' segments.\n")
         sys.exit(1)
@@ -111,6 +113,11 @@ def resolve_within_base(user_value: str, base_dir: pathlib.Path, label: str) -> 
     if candidate.is_absolute():
         print(f"\n  ❌  Unsafe {label} path: {user_value}")
         print(f"      {label} must be a relative path within: {base_resolved}\n")
+        sys.exit(1)
+
+    if not re.fullmatch(r"[A-Za-z0-9._/\-]+", normalized_input):
+        print(f"\n  ❌  Unsafe {label} path: {user_value}")
+        print(f"      {label} contains unsupported characters.\n")
         sys.exit(1)
 
     resolved = (base_resolved / candidate).resolve()


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/149](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/149)

The best fix is to make the sanitization step explicit and strict before combining with `base_dir`, so the user input cannot contain path separators or traversal semantics at all. In this script, `--output`, `--manifest`, and `--schema` are intended to be local names/relative paths within the script directory; we can safely constrain them to simple path components (letters, digits, `_`, `-`, `.`, and `/` as relative separators if needed) and still preserve expected behavior.

In `docs/rtt/guild/Little_Science_Series/ingest.py`, update `resolve_within_base` to:

1. Normalize and validate `user_value` as text.
2. Reject absolute paths and traversal as today.
3. Add a strict regex allowlist for safe relative path characters.
4. Resolve and enforce containment (existing logic).

No new dependency is needed; `re` is already imported. This keeps functionality (relative paths under project dir) while reducing taint ambiguity for static analysis and strengthening security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
