### PR TITLE
Potential fix for code scanning alert no. 91: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/rsm-shim/validate.py
+++ b/docs/resonance-substrate-model/rsm-shim/validate.py
@@ -4,13 +4,23 @@ import sys
 from pathlib import Path
 
 SCHEMA_DIR = Path("../schemas")
+CONFIG_DIR = Path(".")
+
+def resolve_safe_path(base_dir, user_path):
+    base = Path(base_dir).resolve()
+    candidate = (base / user_path).resolve()
+    if base != candidate and base not in candidate.parents:
+        raise ValueError(f"Config path escapes allowed directory: {user_path}")
+    return candidate
 
 def load_schema(name):
     with open(SCHEMA_DIR / name, "r") as f:
         return json.load(f)
 
 def validate_config(config_path):
-    config = json.load(open(config_path))
+    safe_config_path = resolve_safe_path(CONFIG_DIR, config_path)
+    with open(safe_config_path, "r") as config_file:
+        config = json.load(config_file)
     schema = load_schema("simulation.schema.json")
     jsonschema.validate(config, schema)
     print("Config is valid.")

--- a/docs/resonance-substrate-model/rsm-shim/validate.py
+++ b/docs/resonance-substrate-model/rsm-shim/validate.py
@@ -9,10 +9,13 @@ CONFIG_DIR = Path(".")
 def resolve_safe_path(base_dir, user_path):
     base = Path(base_dir).resolve()
     user_path_obj = Path(user_path)
-    if user_path_obj.is_absolute() or ".." in user_path_obj.parts:
+    if user_path_obj.is_absolute():
         raise ValueError(f"Config path escapes allowed directory: {user_path}")
+
     candidate = (base / user_path_obj).resolve()
-    if base != candidate and base not in candidate.parents:
+    try:
+        candidate.relative_to(base)
+    except ValueError:
         raise ValueError(f"Config path escapes allowed directory: {user_path}")
     return candidate
 

--- a/docs/resonance-substrate-model/rsm-shim/validate.py
+++ b/docs/resonance-substrate-model/rsm-shim/validate.py
@@ -8,13 +8,17 @@ CONFIG_DIR = Path(".")
 
 def resolve_safe_path(base_dir, user_path):
     base = Path(base_dir).resolve()
-    candidate = (base / user_path).resolve()
+    user_path_obj = Path(user_path)
+    if user_path_obj.is_absolute() or ".." in user_path_obj.parts:
+        raise ValueError(f"Config path escapes allowed directory: {user_path}")
+    candidate = (base / user_path_obj).resolve()
     if base != candidate and base not in candidate.parents:
         raise ValueError(f"Config path escapes allowed directory: {user_path}")
     return candidate
 
 def load_schema(name):
-    with open(SCHEMA_DIR / name, "r") as f:
+    safe_schema_path = resolve_safe_path(SCHEMA_DIR, name)
+    with open(safe_schema_path, "r") as f:
         return json.load(f)
 
 def validate_config(config_path):

--- a/docs/resonance-substrate-model/rsm-shim/validate.py
+++ b/docs/resonance-substrate-model/rsm-shim/validate.py
@@ -36,7 +36,8 @@ def load_schema(name):
 
 def validate_config(config_path):
     safe_config_name = sanitize_config_filename(config_path)
-    with open(safe_config_name, "r") as config_file:
+    safe_config_path = resolve_safe_path(CONFIG_DIR, safe_config_name)
+    with open(safe_config_path, "r") as config_file:
         config = json.load(config_file)
     schema = load_schema("simulation.schema.json")
     jsonschema.validate(config, schema)

--- a/docs/resonance-substrate-model/rsm-shim/validate.py
+++ b/docs/resonance-substrate-model/rsm-shim/validate.py
@@ -36,8 +36,7 @@ def load_schema(name):
 
 def validate_config(config_path):
     safe_config_name = sanitize_config_filename(config_path)
-    safe_config_path = resolve_safe_path(CONFIG_DIR, safe_config_name)
-    with open(safe_config_path, "r") as config_file:
+    with open(safe_config_name, "r") as config_file:
         config = json.load(config_file)
     schema = load_schema("simulation.schema.json")
     jsonschema.validate(config, schema)

--- a/docs/resonance-substrate-model/rsm-shim/validate.py
+++ b/docs/resonance-substrate-model/rsm-shim/validate.py
@@ -16,13 +16,24 @@ def resolve_safe_path(base_dir, user_path):
         raise ValueError(f"Config path escapes allowed directory: {user_path}")
     return candidate
 
+def sanitize_config_filename(config_path):
+    config_name = Path(config_path).name
+    if config_name != config_path:
+        raise ValueError(f"Config path must be a file in the current directory: {config_path}")
+    if config_name in ("", ".", ".."):
+        raise ValueError(f"Invalid config filename: {config_path}")
+    if Path(config_name).suffix.lower() != ".json":
+        raise ValueError(f"Config file must be a .json file: {config_path}")
+    return config_name
+
 def load_schema(name):
     safe_schema_path = resolve_safe_path(SCHEMA_DIR, name)
     with open(safe_schema_path, "r") as f:
         return json.load(f)
 
 def validate_config(config_path):
-    safe_config_path = resolve_safe_path(CONFIG_DIR, config_path)
+    safe_config_name = sanitize_config_filename(config_path)
+    safe_config_path = resolve_safe_path(CONFIG_DIR, safe_config_name)
     with open(safe_config_path, "r") as config_file:
         config = json.load(config_file)
     schema = load_schema("simulation.schema.json")


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/91](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/91)

To fix this safely, resolve the user-provided path against an allowed base directory, normalize it (`resolve()`), and ensure the resolved target remains inside that base before opening. This removes traversal and absolute-path escape risks while keeping functionality (validating config files) intact.

Best concrete change in `docs/resonance-substrate-model/rsm-shim/validate.py`:
- Introduce a `CONFIG_DIR` safe root (adjacent to existing schema root conventions).
- Add a helper `resolve_safe_path(base_dir, user_path)` that:
  - resolves both base and candidate paths,
  - rejects paths that do not stay under `base_dir`.
- Update `validate_config` to use the validated/resolved path and open via context manager.
- Keep existing imports; `Path` is already imported, so no new dependency is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
