### PR TITLE
Potential fix for code scanning alert no. 107: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/tools/cli/validate.py
+++ b/docs/resonance-substrate-model/tools/cli/validate.py
@@ -29,25 +29,32 @@ from pathlib import Path
 
 def ensure_within_root(path: Path, root: Path, label: str) -> Path:
     # Normalize incoming value defensively before validation.
-    raw_value = str(path)
-    normalized_value = os.path.normpath(raw_value)
-    candidate = Path(normalized_value)
-
-    # Treat user-provided paths as repository-relative only.
-    if candidate.is_absolute():
-        error(f"{label} must be a relative path: {candidate}")
+    raw_value = str(path).strip()
+    normalized_value = os.path.normpath(raw_value.replace("\\", "/"))
 
     if normalized_value in ("", "."):
-        error(f"{label} must not be empty: {candidate}")
+        error(f"{label} must not be empty: {normalized_value}")
+
+    # Treat user-provided paths as repository-relative only.
+    if normalized_value.startswith("/") or os.path.isabs(normalized_value):
+        error(f"{label} must be a relative path: {normalized_value}")
+
+    # Block Windows drive-qualified paths (e.g. C:/...).
+    drive, _ = os.path.splitdrive(normalized_value)
+    if drive:
+        error(f"{label} must not include a drive prefix: {normalized_value}")
 
     # Block explicit traversal attempts before touching the filesystem.
-    if any(part == ".." for part in candidate.parts):
-        error(f"{label} must not contain parent directory traversal: {candidate}")
+    parts = [part for part in normalized_value.split("/") if part not in ("", ".")]
+    if any(part == ".." for part in parts):
+        error(f"{label} must not contain parent directory traversal: {normalized_value}")
+
+    safe_candidate = Path(*parts)
 
     resolved_root = root.resolve()
-    resolved = (resolved_root / candidate).resolve(strict=False)
+    resolved = (resolved_root / safe_candidate).resolve(strict=False)
     if not resolved.is_relative_to(resolved_root):
-        error(f"{label} escapes repository root: {candidate}")
+        error(f"{label} escapes repository root: {normalized_value}")
     return resolved
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/107](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/107)

Best fix: avoid composing a filesystem path from tainted input in a way that remains tainted to CodeQL, by sanitizing input as a **relative POSIX-like path string**, rejecting dangerous forms early, and only then converting to `Path` and resolving under the repo root. This preserves existing behavior (relative paths inside repo only) while making validation stricter and clearer.

In `docs/resonance-substrate-model/tools/cli/validate.py`, update `ensure_within_root` to:

- Normalize separators (`\` → `/`) and use `os.path.normpath`.
- Reject empty, `"."`, absolute, drive-qualified, and `".."` traversal inputs using string/part checks before path join.
- Build a sanitized relative `Path` from safe parts only.
- Resolve with `(resolved_root / safe_candidate).resolve(strict=False)` and keep the existing containment check.

No external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
