### PR TITLE
Potential fix for code scanning alert no. 83: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/tools/cli/rtt-schema.py
+++ b/docs/resonance-substrate-model/tools/cli/rtt-schema.py
@@ -44,12 +44,13 @@ def constrain_to_base(path: Path, base: Path) -> Path:
     return candidate
 
 
-def load_json(path: Path):
+def load_json(path: Path, base: Path):
+    safe_path = constrain_to_base(path, base)
     try:
-        with open(path, "r", encoding="utf-8") as f:
+        with open(safe_path, "r", encoding="utf-8") as f:
             return json.load(f)
     except json.JSONDecodeError as e:
-        print(f"[ERROR] Invalid JSON in {path}: {e}")
+        print(f"[ERROR] Invalid JSON in {safe_path}: {e}")
         sys.exit(1)
 
 
@@ -67,7 +68,7 @@ def ok(msg):
 # ------------------------------------------------------------
 
 def inspect_schema(path: Path):
-    schema = load_json(path)
+    schema = load_json(path, Path.cwd())
 
     print("Schema Metadata")
     print("---------------")

--- a/docs/resonance-substrate-model/tools/cli/rtt-schema.py
+++ b/docs/resonance-substrate-model/tools/cli/rtt-schema.py
@@ -33,8 +33,10 @@ from pathlib import Path
 # ------------------------------------------------------------
 
 def constrain_to_base(path: Path, base: Path) -> Path:
-    candidate = path.expanduser().resolve()
     base_resolved = base.expanduser().resolve()
+    user_path = path.expanduser()
+    candidate = user_path if user_path.is_absolute() else (base_resolved / user_path)
+    candidate = candidate.resolve(strict=False)
     try:
         candidate.relative_to(base_resolved)
     except ValueError:

--- a/docs/resonance-substrate-model/tools/cli/rtt-schema.py
+++ b/docs/resonance-substrate-model/tools/cli/rtt-schema.py
@@ -35,8 +35,14 @@ from pathlib import Path
 def constrain_to_base(path: Path, base: Path) -> Path:
     base_resolved = base.expanduser().resolve()
     user_path = path
-    candidate = user_path if user_path.is_absolute() else (base_resolved / user_path)
-    candidate = candidate.resolve(strict=False)
+
+    if user_path.is_absolute():
+        error(f"Absolute paths are not allowed: {path}")
+
+    if any(part == ".." for part in user_path.parts):
+        error(f"Path traversal is not allowed: {path}")
+
+    candidate = (base_resolved / user_path).resolve(strict=False)
     try:
         candidate.relative_to(base_resolved)
     except ValueError:

--- a/docs/resonance-substrate-model/tools/cli/rtt-schema.py
+++ b/docs/resonance-substrate-model/tools/cli/rtt-schema.py
@@ -32,6 +32,16 @@ from pathlib import Path
 # Utility
 # ------------------------------------------------------------
 
+def constrain_to_base(path: Path, base: Path) -> Path:
+    candidate = path.expanduser().resolve()
+    base_resolved = base.expanduser().resolve()
+    try:
+        candidate.relative_to(base_resolved)
+    except ValueError:
+        error(f"Path escapes allowed root: {path}")
+    return candidate
+
+
 def load_json(path: Path):
     try:
         with open(path, "r", encoding="utf-8") as f:
@@ -218,7 +228,8 @@ def main():
         sys.exit(1)
 
     cmd = sys.argv[1]
-    target = Path(sys.argv[2])
+    base_dir = Path.cwd()
+    target = constrain_to_base(Path(sys.argv[2]), base_dir)
 
     if cmd == "inspect":
         inspect_schema(target)
@@ -227,7 +238,7 @@ def main():
     elif cmd == "validate-data":
         if "--schema" not in sys.argv:
             error("Missing --schema argument")
-        schema_path = Path(sys.argv[sys.argv.index("--schema") + 1])
+        schema_path = constrain_to_base(Path(sys.argv[sys.argv.index("--schema") + 1]), base_dir)
         validate_data(target, schema_path)
     elif cmd == "to-markdown":
         to_markdown(target)

--- a/docs/resonance-substrate-model/tools/cli/rtt-schema.py
+++ b/docs/resonance-substrate-model/tools/cli/rtt-schema.py
@@ -34,7 +34,7 @@ from pathlib import Path
 
 def constrain_to_base(path: Path, base: Path) -> Path:
     base_resolved = base.expanduser().resolve()
-    user_path = path.expanduser()
+    user_path = path
     candidate = user_path if user_path.is_absolute() else (base_resolved / user_path)
     candidate = candidate.resolve(strict=False)
     try:

--- a/docs/resonance-substrate-model/tools/cli/rtt-schema.py
+++ b/docs/resonance-substrate-model/tools/cli/rtt-schema.py
@@ -34,15 +34,19 @@ from pathlib import Path
 
 def constrain_to_base(path: Path, base: Path) -> Path:
     base_resolved = base.expanduser().resolve()
-    user_path = path
+    user_path = Path(str(path))
+
+    if not str(user_path):
+        error("Empty path is not allowed")
 
     if user_path.is_absolute():
         error(f"Absolute paths are not allowed: {path}")
 
-    if any(part == ".." for part in user_path.parts):
+    parts = user_path.parts
+    if any(part in ("..", "") for part in parts):
         error(f"Path traversal is not allowed: {path}")
 
-    candidate = (base_resolved / user_path).resolve(strict=False)
+    candidate = base_resolved.joinpath(*parts).resolve(strict=False)
     try:
         candidate.relative_to(base_resolved)
     except ValueError:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/83](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/83)

The best fix is to canonicalize and validate user-provided paths against an allowed base directory before using them in filesystem operations.

In `docs/resonance-substrate-model/tools/cli/rtt-schema.py`, add a helper that:
- resolves the candidate path (`expanduser().resolve()`),
- resolves a trusted base (current working directory is a practical default here),
- ensures the candidate is the base or a descendant (`relative_to` check),
- exits with a clear error if invalid.

Then, in `main()`, sanitize `target` immediately after reading `sys.argv[2]`, and sanitize `schema_path` in the `validate-data` branch as well. This preserves existing behavior for normal in-repo usage while preventing traversal to arbitrary locations outside the allowed root.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
