### PR TITLE
Potential fix for code scanning alert no. 170: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/rsm-shim/validate.py
+++ b/docs/resonance-substrate-model/rsm-shim/validate.py
@@ -12,7 +12,11 @@ def resolve_safe_path(base_dir, user_path):
     if user_path_obj.is_absolute():
         raise ValueError(f"Config path escapes allowed directory: {user_path}")
 
-    candidate = (base / user_path_obj).resolve()
+    normalized_user_path = Path(*user_path_obj.parts)
+    if any(part == ".." for part in normalized_user_path.parts):
+        raise ValueError(f"Config path escapes allowed directory: {user_path}")
+
+    candidate = (base / normalized_user_path).resolve()
     try:
         candidate.relative_to(base)
     except ValueError:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/170](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/170)

Use strict path canonicalization and containment checks in `resolve_safe_path` before any filesystem access.  
Best fix: normalize the user path lexically, reject absolute and traversal attempts (`..`), then build an absolute path under a fixed base and verify it remains under that base.

In `docs/resonance-substrate-model/rsm-shim/validate.py`, update `resolve_safe_path` (lines 9–20 region) to:

- Resolve `base_dir` once (`base = Path(base_dir).resolve()`).
- Parse input path.
- Reject absolute paths.
- Normalize input with `Path(*user_path_obj.parts)` and reject any `..` path segments.
- Join with base, resolve, and enforce `candidate.relative_to(base)`.

No new imports are required; `pathlib.Path` is already imported. This keeps existing functionality while making traversal prevention explicit and robust for current and future callers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
