### PR TITLE
Potential fix for code scanning alert no. 130: Uncontrolled data used in path expression

### DIFF
--- a/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
+++ b/docs/TFT_3Pack_v1.3/tft/entft/encryptor.py
@@ -61,7 +61,7 @@ def encrypt(input_path, output_path, key):
 
     # Simulated encryption output
     encrypted = f"{resonance_hash[:32]}...{resonance_hash[-32:]}"
-    safe_output_path = output_path if isinstance(output_path, Path) else _sanitize_output_path(output_path)
+    safe_output_path = _sanitize_output_path(output_path)
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/130](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/130)

General fix: enforce path sanitization/validation at the sink boundary unconditionally, regardless of input type or caller. Do not trust upstream validation alone.

Best fix here: in `docs/TFT_3Pack_v1.3/tft/entft/encryptor.py`, update `encrypt()` so `output_path` is always passed through `_sanitize_output_path`. This preserves current functionality for valid CLI inputs while preventing bypass via direct API calls with `Path` objects. Specifically replace line 64 logic with unconditional sanitization:
- from: conditional `Path` bypass
- to: `safe_output_path = _sanitize_output_path(output_path)`

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
