### PR TITLE
Potential fix for code scanning alert no. 90: Uncontrolled data used in path expression

### DIFF
--- a/docs/archive_experiments/engine/simulate.py
+++ b/docs/archive_experiments/engine/simulate.py
@@ -22,6 +22,16 @@ def _validate_output_filename(filename):
         raise ValueError("Invalid output filename: contains unsafe characters")
     return filename
 
+def _safe_join_under_root(root, filename):
+    safe_name = _validate_output_filename(filename)
+    root_resolved = Path(root).resolve()
+    candidate = (root_resolved / safe_name).resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError:
+        raise ValueError("Invalid output filename: output path escapes docs/reports")
+    return candidate
+
 def run_simulation(manifest_path):
     with open(manifest_path, 'r') as f:
         manifest = yaml.safe_load(f)
@@ -35,12 +45,8 @@ def run_simulation(manifest_path):
     signals = generate_triphasic_signals(forces, fluids, frequency, cycles=3500)
 
     reports_root = Path("docs/reports").resolve()
-    output_filename = _validate_output_filename(f"{safe_label}_cycles.csv")
-    output_path = (reports_root / output_filename).resolve()
-    try:
-        output_path.relative_to(reports_root)
-    except ValueError:
-        raise ValueError("Invalid manifest label: output path escapes docs/reports")
+    output_filename = f"{safe_label}_cycles.csv"
+    output_path = _safe_join_under_root(reports_root, output_filename)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/docs/archive_experiments/engine/simulate.py
+++ b/docs/archive_experiments/engine/simulate.py
@@ -1,14 +1,23 @@
 import yaml
 import csv
+import re
 from pathlib import Path
 
 from triphasic import generate_triphasic_signals
+
+def _sanitize_label(label):
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", str(label).strip())
+    safe = safe.strip("._-")
+    if not safe:
+        raise ValueError("Invalid manifest label: label must contain at least one safe character")
+    return safe
 
 def run_simulation(manifest_path):
     with open(manifest_path, 'r') as f:
         manifest = yaml.safe_load(f)
 
     label = manifest['label']
+    safe_label = _sanitize_label(label)
     forces = manifest['forces']
     fluids = manifest['fluids']
     frequency = manifest['frequency']
@@ -16,7 +25,7 @@ def run_simulation(manifest_path):
     signals = generate_triphasic_signals(forces, fluids, frequency, cycles=3500)
 
     reports_root = Path("docs/reports").resolve()
-    output_path = (reports_root / f"{label}_cycles.csv").resolve()
+    output_path = (reports_root / f"{safe_label}_cycles.csv").resolve()
     try:
         output_path.relative_to(reports_root)
     except ValueError:

--- a/docs/archive_experiments/engine/simulate.py
+++ b/docs/archive_experiments/engine/simulate.py
@@ -12,6 +12,16 @@ def _sanitize_label(label):
         raise ValueError("Invalid manifest label: label must contain at least one safe character")
     return safe
 
+def _validate_output_filename(filename):
+    if not filename:
+        raise ValueError("Invalid output filename: empty filename is not allowed")
+    filename_path = Path(filename)
+    if filename_path.is_absolute() or filename_path.name != filename:
+        raise ValueError("Invalid output filename: path separators are not allowed")
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", filename):
+        raise ValueError("Invalid output filename: contains unsafe characters")
+    return filename
+
 def run_simulation(manifest_path):
     with open(manifest_path, 'r') as f:
         manifest = yaml.safe_load(f)
@@ -25,7 +35,8 @@ def run_simulation(manifest_path):
     signals = generate_triphasic_signals(forces, fluids, frequency, cycles=3500)
 
     reports_root = Path("docs/reports").resolve()
-    output_path = (reports_root / f"{safe_label}_cycles.csv").resolve()
+    output_filename = _validate_output_filename(f"{safe_label}_cycles.csv")
+    output_path = (reports_root / output_filename).resolve()
     try:
         output_path.relative_to(reports_root)
     except ValueError:

--- a/docs/archive_experiments/engine/simulate.py
+++ b/docs/archive_experiments/engine/simulate.py
@@ -15,7 +15,13 @@ def run_simulation(manifest_path):
 
     signals = generate_triphasic_signals(forces, fluids, frequency, cycles=3500)
 
-    output_path = Path(f"docs/reports/{label}_cycles.csv")
+    reports_root = Path("docs/reports").resolve()
+    output_path = (reports_root / f"{label}_cycles.csv").resolve()
+    try:
+        output_path.relative_to(reports_root)
+    except ValueError:
+        raise ValueError("Invalid manifest label: output path escapes docs/reports")
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, 'w', newline='') as f:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/90](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/90)

The best fix is to constrain the final output path to a known safe root directory after normalization/resolution, and reject labels that escape that directory.

In `docs/archive_experiments/engine/simulate.py`, replace the current path construction at line 18 with:
1. A fixed base directory `docs/reports` resolved to an absolute path.
2. A candidate file path built from `label`.
3. Resolution/normalization of that candidate path.
4. A containment check ensuring the resolved candidate is inside the resolved base directory (using `relative_to`).
5. Raise a clear exception if validation fails.

This preserves existing functionality (still writes `<label>_cycles.csv` under `docs/reports`) while blocking traversal/absolute-path abuse. No new imports are needed since `Path` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
