### PR TITLE
Potential fix for code scanning alert no. 87: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
+++ b/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
@@ -124,7 +124,11 @@ def main():
         print(f"Error: path is outside allowed directory: {user_input_path}")
         sys.exit(1)
 
-    if not schema_path.exists():
+    if schema_path.suffix.lower() != ".json":
+        print(f"Error: only .json schema files are allowed: {schema_path}")
+        sys.exit(1)
+
+    if not schema_path.exists() or not schema_path.is_file():
         print(f"Error: file not found: {schema_path}")
         sys.exit(1)
 

--- a/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
+++ b/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
@@ -115,6 +115,14 @@ def main():
         sys.exit(1)
 
     user_input_path = Path(sys.argv[1])
+    if user_input_path.is_absolute():
+        print(f"Error: absolute paths are not allowed: {user_input_path}")
+        sys.exit(1)
+
+    if ".." in user_input_path.parts:
+        print(f"Error: parent directory traversal is not allowed: {user_input_path}")
+        sys.exit(1)
+
     safe_root = Path.cwd().resolve()
     schema_path = (safe_root / user_input_path).resolve()
 

--- a/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
+++ b/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
@@ -114,7 +114,16 @@ def main():
         print("Usage: python schema_to_markdown.py path/to/schema.json")
         sys.exit(1)
 
-    schema_path = Path(sys.argv[1])
+    user_input_path = Path(sys.argv[1])
+    safe_root = Path.cwd().resolve()
+    schema_path = (safe_root / user_input_path).resolve()
+
+    try:
+        schema_path.relative_to(safe_root)
+    except ValueError:
+        print(f"Error: path is outside allowed directory: {user_input_path}")
+        sys.exit(1)
+
     if not schema_path.exists():
         print(f"Error: file not found: {schema_path}")
         sys.exit(1)

--- a/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
+++ b/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
@@ -46,7 +46,12 @@ def load_schema(path):
 
 def resolve_valid_schema_path(user_input_path, safe_root):
     root = Path(safe_root).resolve()
-    candidate = (root / user_input_path).resolve()
+    requested = Path(user_input_path)
+
+    if requested.is_absolute():
+        raise ValueError(f"absolute paths are not allowed: {requested}")
+
+    candidate = (root / requested).resolve()
 
     try:
         candidate.relative_to(root)
@@ -129,14 +134,7 @@ def main():
         print("Usage: python schema_to_markdown.py path/to/schema.json")
         sys.exit(1)
 
-    user_input_path = Path(sys.argv[1])
-    if user_input_path.is_absolute():
-        print(f"Error: absolute paths are not allowed: {user_input_path}")
-        sys.exit(1)
-
-    if ".." in user_input_path.parts:
-        print(f"Error: parent directory traversal is not allowed: {user_input_path}")
-        sys.exit(1)
+    user_input_path = sys.argv[1]
 
     safe_root = Path.cwd().resolve()
 

--- a/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
+++ b/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
@@ -44,6 +44,21 @@ def load_schema(path):
         return json.load(f)
 
 
+def resolve_valid_schema_path(user_input_path, safe_root):
+    root = Path(safe_root).resolve()
+    candidate = (root / user_input_path).resolve()
+
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"path is outside allowed directory: {user_input_path}") from exc
+
+    if candidate.suffix.lower() != ".json":
+        raise ValueError(f"only .json schema files are allowed: {candidate}")
+
+    return candidate
+
+
 def extract_properties(schema):
     return schema.get("properties", {})
 
@@ -124,16 +139,11 @@ def main():
         sys.exit(1)
 
     safe_root = Path.cwd().resolve()
-    schema_path = (safe_root / user_input_path).resolve()
 
     try:
-        schema_path.relative_to(safe_root)
-    except ValueError:
-        print(f"Error: path is outside allowed directory: {user_input_path}")
-        sys.exit(1)
-
-    if schema_path.suffix.lower() != ".json":
-        print(f"Error: only .json schema files are allowed: {schema_path}")
+        schema_path = resolve_valid_schema_path(user_input_path, safe_root)
+    except ValueError as err:
+        print(f"Error: {err}")
         sys.exit(1)
 
     if not schema_path.exists() or not schema_path.is_file():


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/87](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/87)

To fix this safely, normalize and resolve the user-supplied path and enforce that it stays within a trusted base directory before any file access. The best minimal fix here is to anchor allowed schema inputs to the current working directory (`Path.cwd()`), resolve both paths, reject absolute/escaping paths, and then proceed with existence checks and loading.

In `docs/resonance-substrate-model/tools/converters/schema_to_markdown.py`, update `main()` around lines 117–120:

- Keep reading `sys.argv[1]`, but store as `user_input_path`.
- Compute `safe_root = Path.cwd().resolve()` and `schema_path = (safe_root / user_input_path).resolve()`.
- Validate containment with `schema_path.relative_to(safe_root)` inside a `try/except ValueError`; on failure, print an error and exit.
- Then keep the existing `exists()` check (now on validated path) and continue unchanged.
- No new dependencies are needed; this uses existing `pathlib.Path`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
