### PR TITLE
Potential fix for code scanning alert no. 188: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
+++ b/docs/resonance-substrate-model/tools/converters/schema_to_markdown.py
@@ -51,7 +51,11 @@ def resolve_valid_schema_path(user_input_path, safe_root):
     if requested.is_absolute():
         raise ValueError(f"absolute paths are not allowed: {requested}")
 
-    candidate = (root / requested).resolve()
+    if ".." in requested.parts:
+        raise ValueError(f"parent directory segments are not allowed: {user_input_path}")
+
+    sanitized_relative = Path(*[part for part in requested.parts if part not in ("", ".")])
+    candidate = (root / sanitized_relative).resolve()
 
     try:
         candidate.relative_to(root)


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/188](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/188)

The best fix is to make the sanitization step explicit and structural before path composition by normalizing and validating the user-provided path parts, rejecting traversal tokens (`..`) and unsafe absolute semantics, then constructing the candidate path from sanitized relative components.

In `docs/resonance-substrate-model/tools/converters/schema_to_markdown.py`, update `resolve_valid_schema_path` so it:

1. Parses user input with `Path(user_input_path)`.
2. Rejects absolute inputs as it already does.
3. Rejects any path containing parent-directory components (`..`) in `requested.parts`.
4. Rebuilds a sanitized relative path from safe parts and joins it to `root`.
5. Keeps the existing containment check (`relative_to(root)`) and `.json` suffix check.

This preserves existing behavior (relative JSON files under current working directory) while making traversal rejection explicit and easier for SAST tools to recognize.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
