### PR TITLE
Potential fix for code scanning alert no. 131: Uncontrolled data used in path expression

### DIFF
--- a/docs/starter/tools/validate.py
+++ b/docs/starter/tools/validate.py
@@ -11,19 +11,20 @@ def load_json(path):
 def safe_resolve_path(base_dir, user_path):
     safe_base = Path(base_dir).resolve()
     user_path = str(user_path).strip()
-    user_rel = Path(user_path)
 
     if not user_path:
         raise ValueError("Path must not be empty")
+
+    normalized = os.path.normpath(user_path)
+    user_rel = Path(normalized)
+
     if user_rel.is_absolute():
         raise ValueError(f"Absolute paths are not allowed: {user_path}")
-    if ".." in user_rel.parts:
+    if normalized == ".." or normalized.startswith(f"..{os.sep}"):
         raise ValueError(f"Path traversal is not allowed: {user_path}")
 
     candidate = (safe_base / user_rel).resolve()
-    try:
-        candidate.relative_to(safe_base)
-    except ValueError:
+    if candidate != safe_base and safe_base not in candidate.parents:
         raise ValueError(f"Path escapes allowed root: {user_path}")
 
     if candidate.suffix.lower() != ".json":


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/131](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/131)

To fix this safely (and quiet the alert), keep all path handling inside a strict safe-root policy:

- Normalize user input with `os.path.normpath`.
- Reject absolute paths and normalized traversal (`..` or leading `../`).
- Build the candidate path under a resolved base directory.
- Resolve and verify that the candidate is inside the base (`candidate == base` or `base in candidate.parents`).
- Keep the `.json` extension allowlist.

In `docs/starter/tools/validate.py`, update `safe_resolve_path` so it validates a normalized string before creating the final `Path`, and use an explicit ancestry check that static analyzers usually recognize. No behavior change is intended besides stricter normalization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
