### PR TITLE
Potential fix for code scanning alert no. 182: Uncontrolled data used in path expression

### DIFF
--- a/docs/archive_experiments/engine/simulate.py
+++ b/docs/archive_experiments/engine/simulate.py
@@ -33,12 +33,23 @@ def _safe_join_under_root(root, filename):
     return candidate
 
 def _safe_manifest_path(manifest_path):
+    if not manifest_path:
+        raise ValueError("Invalid manifest path: empty path is not allowed")
+
+    user_path = Path(str(manifest_path))
+    if user_path.is_absolute():
+        raise ValueError("Invalid manifest path: absolute paths are not allowed")
+    if ".." in user_path.parts:
+        raise ValueError("Invalid manifest path: parent directory traversal is not allowed")
+
     manifests_root = Path("docs/manifests").resolve()
-    candidate = (manifests_root / manifest_path).resolve()
+    candidate = (manifests_root / user_path).resolve()
     try:
         candidate.relative_to(manifests_root)
     except ValueError:
         raise ValueError("Invalid manifest path: path escapes docs/manifests")
+    if candidate.suffix.lower() not in {".yaml", ".yml"}:
+        raise ValueError("Invalid manifest path: expected a .yaml or .yml file")
     if not candidate.is_file():
         raise ValueError("Invalid manifest path: file does not exist")
     return candidate

--- a/docs/archive_experiments/engine/simulate.py
+++ b/docs/archive_experiments/engine/simulate.py
@@ -32,8 +32,20 @@ def _safe_join_under_root(root, filename):
         raise ValueError("Invalid output filename: output path escapes docs/reports")
     return candidate
 
+def _safe_manifest_path(manifest_path):
+    manifests_root = Path("docs/manifests").resolve()
+    candidate = (manifests_root / manifest_path).resolve()
+    try:
+        candidate.relative_to(manifests_root)
+    except ValueError:
+        raise ValueError("Invalid manifest path: path escapes docs/manifests")
+    if not candidate.is_file():
+        raise ValueError("Invalid manifest path: file does not exist")
+    return candidate
+
 def run_simulation(manifest_path):
-    with open(manifest_path, 'r') as f:
+    safe_manifest_path = _safe_manifest_path(manifest_path)
+    with open(safe_manifest_path, 'r') as f:
         manifest = yaml.safe_load(f)
 
     label = manifest['label']


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/182](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/182)

General fix: constrain untrusted path input to a known safe root directory, normalize/resolve it, and verify the resolved path remains under that root before opening.

Best fix here (without changing core functionality): add a helper to safely resolve a manifest path under `docs/manifests`, and use it in `run_simulation` before `open()`. This mirrors your existing `_safe_join_under_root` strategy and keeps behavior deterministic and safe.

Specific edits in `docs/archive_experiments/engine/simulate.py`:
- Add `_safe_manifest_path(manifest_path)` near other path helpers.
- In `run_simulation`, resolve `manifest_path` through this helper and open the validated path instead of raw input.
- Keep existing imports; `Path` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
