### PR TITLE
Potential fix for code scanning alert no. 177: Clear-text logging of sensitive information

### DIFF
--- a/docs/rtt/codes/generators/python/generate_rttcode.py
+++ b/docs/rtt/codes/generators/python/generate_rttcode.py
@@ -143,7 +143,7 @@ def main():
     print("RTTcode URL:", rtt_url)
 
     generate_qr_code(rtt_url, safe_output_path)
-    print("QR code saved to:", trusted_output_name)
+    print("QR code generated successfully.")
 
 if __name__ == "__main__":
     main()

--- a/docs/rtt/codes/generators/python/generate_rttcode.py
+++ b/docs/rtt/codes/generators/python/generate_rttcode.py
@@ -143,7 +143,7 @@ def main():
     print("RTTcode URL:", rtt_url)
 
     generate_qr_code(rtt_url, safe_output_path)
-    print("QR code saved to:", safe_output_path)
+    print("QR code saved to:", trusted_output_name)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/177](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/177)

General fix: avoid logging sensitive or potentially sensitive path values in clear text. Log non-sensitive metadata instead (for example, a fixed success message or sanitized basename), while keeping core behavior unchanged.

Best targeted fix here: in `docs/rtt/codes/generators/python/generate_rttcode.py`, replace the line that prints `safe_output_path` with a message that uses the already-trusted allowlisted filename (`trusted_output_name`) or a constant message. This removes disclosure of the absolute resolved path while preserving user feedback that generation succeeded.

Change region:
- `main()` near lines 145–147.
- Replace `print("QR code saved to:", safe_output_path)` with `print("QR code saved to:", trusted_output_name)`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
