### PR TITLE
Potential fix for code scanning alert no. 149: Uncontrolled data used in path expression

### DIFF
--- a/docs/rtt/guild/Little_Science_Series/ingest.py
+++ b/docs/rtt/guild/Little_Science_Series/ingest.py
@@ -149,7 +149,8 @@ def resolve_within_base(user_value: str, base_dir: pathlib.Path, label: str) -> 
         print(f"      {label} contains unsupported characters.\n")
         sys.exit(1)
 
-    resolved = (base_resolved / candidate).resolve()
+    safe_relative = pathlib.Path(normalized_input.lstrip("/\\"))
+    resolved = base_resolved.joinpath(safe_relative).resolve()
     try:
         resolved.relative_to(base_resolved)
     except ValueError:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/149](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/149)

General fix: ensure user input is normalized and converted to a strictly relative path before joining with the trusted base, then enforce containment on the resolved result.

Best fix here (minimal behavior change): in `resolve_within_base` (around lines 134–153), replace direct use of `candidate` in `base_resolved / candidate` with a normalized relative path string and `joinpath`, stripping leading slashes/backslashes to prevent accidental absolute semantics. Keep the existing validation and final `relative_to` check.

Changes needed in `docs/rtt/guild/Little_Science_Series/ingest.py`:
- In `resolve_within_base`, after creating `candidate`, build `safe_relative = pathlib.Path(normalized_input.lstrip("/\\"))`.
- Use `resolved = base_resolved.joinpath(safe_relative).resolve()` instead of `base_resolved / candidate`.
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
