### PR TITLE
Potential fix for code scanning alert no. 132: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/tools/cli/inspect_schema.py
+++ b/docs/resonance-substrate-model/tools/cli/inspect_schema.py
@@ -41,24 +41,28 @@ def error(msg):
 
 def validate_schema_path(user_input: str) -> Path:
     # Restrict schema inspection to files under docs/resonance-substrate-model
-    safe_root = Path(__file__).resolve().parents[1].resolve()
+    safe_root = Path(__file__).resolve().parents[2].resolve()
+    if not safe_root.exists() or not safe_root.is_dir():
+        error(f"Safe root is invalid or missing: {safe_root}")
+
     candidate = Path(user_input).expanduser()
     candidate = candidate if candidate.is_absolute() else (Path.cwd() / candidate)
-    resolved = candidate.resolve(strict=False)
+
+    if candidate.suffix.lower() != ".json":
+        error("Schema path must point to a .json file")
+
+    if not candidate.exists():
+        error(f"Schema file not found: {candidate}")
+
+    if not candidate.is_file():
+        error(f"Schema path must be a regular file: {candidate}")
+
+    resolved = candidate.resolve(strict=True)
 
     try:
         resolved.relative_to(safe_root)
     except ValueError:
         error(f"Path is outside allowed directory: {safe_root}")
-
-    if resolved.suffix.lower() != ".json":
-        error("Schema path must point to a .json file")
-
-    if not resolved.exists():
-        error(f"Schema file not found: {resolved}")
-
-    if not resolved.is_file():
-        error(f"Schema path must be a regular file: {resolved}")
 
     return resolved
 


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/132](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/132)

To fix this without changing intended functionality, keep accepting a CLI path but harden validation so file access is guaranteed to stay inside a trusted base directory after full canonical resolution.

Best concrete change in `docs/resonance-substrate-model/tools/cli/inspect_schema.py`:
1. In `validate_schema_path`, set `safe_root` to the explicit `docs/resonance-substrate-model` directory from the script location.
2. Check that `safe_root` exists and is a directory.
3. Resolve `candidate` with `strict=True` after existence checks so symlinks are fully dereferenced before containment validation.
4. Keep the `relative_to` containment check against canonical paths.

This preserves current CLI behavior (user supplies a schema path) while making traversal/symlink bypasses much harder and making the trust boundary explicit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
