### PR TITLE
Potential fix for code scanning alert no. 85: Uncontrolled data used in path expression

### DIFF
--- a/docs/resonance-substrate-model/tools/converters/schema_to_graphviz.py
+++ b/docs/resonance-substrate-model/tools/converters/schema_to_graphviz.py
@@ -52,6 +52,17 @@ def load_schema(path):
         return json.load(f)
 
 
+def validate_schema_path(raw_path):
+    schema_path = Path(raw_path).expanduser().resolve()
+    if not schema_path.exists():
+        raise ValueError(f"file not found: {schema_path}")
+    if not schema_path.is_file():
+        raise ValueError(f"not a file: {schema_path}")
+    if schema_path.suffix.lower() != ".json":
+        raise ValueError(f"expected a .json file: {schema_path}")
+    return schema_path
+
+
 def extract_properties(schema):
     return schema.get("properties", {})
 
@@ -107,9 +118,10 @@ def main():
         print("Usage: python schema_to_graphviz.py path/to/schema.json")
         sys.exit(1)
 
-    schema_path = Path(sys.argv[1])
-    if not schema_path.exists():
-        print(f"Error: file not found: {schema_path}")
+    try:
+        schema_path = validate_schema_path(sys.argv[1])
+    except ValueError as exc:
+        print(f"Error: {exc}")
         sys.exit(1)
 
     schema = load_schema(schema_path)

--- a/docs/resonance-substrate-model/tools/converters/schema_to_graphviz.py
+++ b/docs/resonance-substrate-model/tools/converters/schema_to_graphviz.py
@@ -53,14 +53,18 @@ def load_schema(path):
 
 
 def validate_schema_path(raw_path):
-    base_dir = Path.cwd().resolve()
-    schema_path = Path(raw_path).expanduser().resolve()
+    base_dir = Path(__file__).resolve().parent
+    candidate = Path(raw_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = (base_dir / candidate)
+    try:
+        schema_path = candidate.resolve(strict=True)
+    except FileNotFoundError:
+        raise ValueError(f"file not found: {candidate}")
     try:
         schema_path.relative_to(base_dir)
     except ValueError:
         raise ValueError(f"path escapes allowed directory: {schema_path}")
-    if not schema_path.exists():
-        raise ValueError(f"file not found: {schema_path}")
     if not schema_path.is_file():
         raise ValueError(f"not a file: {schema_path}")
     if schema_path.suffix.lower() != ".json":

--- a/docs/resonance-substrate-model/tools/converters/schema_to_graphviz.py
+++ b/docs/resonance-substrate-model/tools/converters/schema_to_graphviz.py
@@ -53,7 +53,12 @@ def load_schema(path):
 
 
 def validate_schema_path(raw_path):
+    base_dir = Path.cwd().resolve()
     schema_path = Path(raw_path).expanduser().resolve()
+    try:
+        schema_path.relative_to(base_dir)
+    except ValueError:
+        raise ValueError(f"path escapes allowed directory: {schema_path}")
     if not schema_path.exists():
         raise ValueError(f"file not found: {schema_path}")
     if not schema_path.is_file():

--- a/docs/resonance-substrate-model/tools/converters/schema_to_graphviz.py
+++ b/docs/resonance-substrate-model/tools/converters/schema_to_graphviz.py
@@ -54,9 +54,18 @@ def load_schema(path):
 
 def validate_schema_path(raw_path):
     base_dir = Path(__file__).resolve().parent
-    candidate = Path(raw_path).expanduser()
-    if not candidate.is_absolute():
-        candidate = (base_dir / candidate)
+
+    raw = str(raw_path).strip()
+    if not raw:
+        raise ValueError("path must not be empty")
+
+    user_path = Path(raw).expanduser()
+    if user_path.is_absolute():
+        raise ValueError(f"absolute paths are not allowed: {user_path}")
+    if ".." in user_path.parts:
+        raise ValueError(f"path traversal is not allowed: {user_path}")
+
+    candidate = base_dir / user_path
     try:
         schema_path = candidate.resolve(strict=True)
     except FileNotFoundError:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/85](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/85)

To fix this safely, normalize and validate the user-supplied path before any filesystem operation, and reject unsafe inputs.  
Best approach here (without changing intended behavior too much): resolve the input to an absolute canonical path, ensure it points to a regular file, and restrict accepted schema files to `.json`. This prevents ambiguous/surprising path forms and narrows accepted inputs to expected schema artifacts.

In `docs/resonance-substrate-model/tools/converters/schema_to_graphviz.py`:
- Add a helper `validate_schema_path(raw_path)` near the schema parsing section.
- In `main()`, replace direct `Path(sys.argv[1])` usage with validated path from helper.
- Keep existing user-facing error handling style (`print` + `sys.exit(1)`), but surface validation errors cleanly.

No new third-party dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
