### PR TITLE
Potential fix for code scanning alert no. 206: Uncontrolled data used in path expression

### DIFF
--- a/build.py
+++ b/build.py
@@ -753,7 +753,11 @@ def main() -> None:
     single_file: Path | None = None
     if args.file:
         docs_root = docs_dir.resolve()
-        single_file = Path(args.file).resolve()
+        requested = Path(args.file)
+        if requested.is_absolute():
+            log.error("--file must be a path relative to %s, got absolute path: %s", docs_root, requested)
+            sys.exit(1)
+        single_file = (docs_root / requested).resolve()
         try:
             single_file.relative_to(docs_root)
         except ValueError:

--- a/build.py
+++ b/build.py
@@ -759,7 +759,7 @@ def main() -> None:
         docs_root = docs_dir.resolve()
         requested = Path(args.file)
         if requested.is_absolute():
-            log.error("--file must be a path relative to %s, got absolute path: %s", docs_root, requested)
+            log.error("--file must be a path relative to %s, got absolute path: %s", docs_root, _safe_for_log(requested))
             sys.exit(1)
         single_file = (docs_root / requested).resolve()
         try:

--- a/build.py
+++ b/build.py
@@ -752,7 +752,13 @@ def main() -> None:
 
     single_file: Path | None = None
     if args.file:
-        single_file = Path(args.file)
+        docs_root = docs_dir.resolve()
+        single_file = Path(args.file).resolve()
+        try:
+            single_file.relative_to(docs_root)
+        except ValueError:
+            log.error("--file must be inside %s, got: %s", docs_root, single_file)
+            sys.exit(1)
         if not single_file.exists():
             log.error("File not found: %s", single_file)
             sys.exit(1)

--- a/build.py
+++ b/build.py
@@ -725,6 +725,10 @@ examples:
     return p.parse_args()
 
 
+def _safe_for_log(value: object) -> str:
+    return str(value).replace("\r", "").replace("\n", "")
+
+
 def main() -> None:
     args = _parse_args()
 
@@ -761,7 +765,7 @@ def main() -> None:
         try:
             single_file.relative_to(docs_root)
         except ValueError:
-            log.error("--file must be inside %s, got: %s", docs_root, single_file)
+            log.error("--file must be inside %s, got: %s", docs_root, _safe_for_log(single_file))
             sys.exit(1)
         if not single_file.exists():
             log.error("File not found: %s", single_file)


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/206](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/206)

General fix: normalize/resolve user-provided paths and enforce that they remain inside an allowed base directory before any filesystem use.

Best fix here (without changing intended functionality): in `main()` inside the `if args.file:` block, resolve both `docs_dir` and the candidate file path, then verify the candidate is within `docs_dir` using `relative_to` (or equivalent). Reject paths outside docs with a clear error. Keep existing checks for existence and `.md` suffix.

Edits needed in `build.py` around lines 753–761:
- Replace `single_file = Path(args.file)` with resolved path handling.
- Add containment check against resolved `docs_dir`.
- Keep existing `exists()` and `.suffix` checks.
- No new dependency required; uses existing `pathlib.Path`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
