### PR TITLE
Potential fix for code scanning alert no. 212: Uncontrolled data used in path expression

### DIFF
--- a/build.py
+++ b/build.py
@@ -729,6 +729,15 @@ def _safe_for_log(value: object) -> str:
     return str(value).replace("\r", "").replace("\n", "")
 
 
+def _validated_relative_md_path_arg(raw_path: str) -> Path:
+    requested = Path(raw_path)
+    if requested.is_absolute():
+        raise ValueError("absolute paths are not allowed")
+    if any(part == ".." for part in requested.parts):
+        raise ValueError("parent traversal is not allowed")
+    return requested
+
+
 def main() -> None:
     args = _parse_args()
 
@@ -757,9 +766,10 @@ def main() -> None:
     single_file: Path | None = None
     if args.file:
         docs_root = docs_dir.resolve()
-        requested = Path(args.file)
-        if requested.is_absolute():
-            log.error("--file must be a path relative to %s, got absolute path: %s", docs_root, _safe_for_log(requested))
+        try:
+            requested = _validated_relative_md_path_arg(args.file)
+        except ValueError:
+            log.error("--file must be a safe path relative to %s, got: %s", docs_root, _safe_for_log(args.file))
             sys.exit(1)
         single_file = (docs_root / requested).resolve()
         try:


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/212](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/212)

General fix: sanitize and validate untrusted path input before constructing/using filesystem paths. Reject absolute paths and any parent-directory traversal segments (`..`) up front, then resolve and enforce that the final path is inside the trusted root.

Best targeted fix in `build.py` (around lines 758–769): add a small helper to validate the user-provided relative path string before joining with `docs_root`. This keeps behavior the same (still allows valid relative `docs/...` files) while blocking traversal patterns earlier and reducing taint concerns.

Changes needed:
- Add a helper function in `build.py` near `_safe_for_log`:
  - Parse input into `Path`
  - Reject absolute paths
  - Reject any `..` segment in `.parts`
  - Return the validated relative `Path`
- Replace `requested = Path(args.file)` with `requested = _validated_relative_md_path_arg(args.file)`.

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
