### PR TITLE
Potential fix for code scanning alert no. 218: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/weekly-checkin.yml
+++ b/.github/workflows/weekly-checkin.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 13 * * 0"   # Runs every Sunday at 09:00 EDT (13:00 UTC)
   workflow_dispatch:        # Allow manual triggering
 
+permissions:
+  contents: write
+
 jobs:
   generate-weekly-checkin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/218](https://github.com/umaywant2/TriadicFrameworks/security/code-scanning/218)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to only what this workflow needs. Since the job commits and pushes a file, it requires `contents: write`. No additional scopes are required by the shown steps.

Best fix (no functional change): in `.github/workflows/weekly-checkin.yml`, add a workflow-level `permissions` section between `on:` and `jobs:`:

- `contents: write`

This preserves current behavior (commit/push still works) while explicitly limiting token capabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
